### PR TITLE
Changing StaffProfile.supervisor to StaffProfile

### DIFF
--- a/app/models/staff_profile.rb
+++ b/app/models/staff_profile.rb
@@ -1,7 +1,7 @@
 class StaffProfile < ApplicationRecord
   belongs_to :user, required: true
   belongs_to :department, required: true
-  belongs_to :supervisor, class_name: "User", optional: true
+  belongs_to :supervisor, class_name: "StaffProfile", optional: true
 
   def to_s
     "#{surname}, #{given_name} (#{user.uid})"

--- a/db/migrate/20190503152336_change_staff_profile_supervisor.rb
+++ b/db/migrate/20190503152336_change_staff_profile_supervisor.rb
@@ -1,0 +1,11 @@
+class ChangeStaffProfileSupervisor < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :staff_profiles, :supervisor_id, :bigint
+    add_reference :staff_profiles, :supervisor, foreign_key: {to_table: :staff_profiles}
+  end
+
+  def down
+    remove_column :staff_profiles, :supervisor_id, :bigint
+    add_reference :staff_profiles, :supervisor, foreign_key: {to_table: :users}
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -355,13 +355,13 @@ CREATE TABLE public.staff_profiles (
     id bigint NOT NULL,
     user_id bigint,
     department_id bigint,
-    supervisor_id bigint,
     biweekly boolean,
     given_name character varying,
     surname character varying,
     email character varying,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    supervisor_id bigint
 );
 
 
@@ -674,7 +674,7 @@ ALTER TABLE ONLY public.approvals
 --
 
 ALTER TABLE ONLY public.staff_profiles
-    ADD CONSTRAINT fk_rails_71cb8bacdd FOREIGN KEY (supervisor_id) REFERENCES public.users(id);
+    ADD CONSTRAINT fk_rails_71cb8bacdd FOREIGN KEY (supervisor_id) REFERENCES public.staff_profiles(id);
 
 
 --
@@ -723,6 +723,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190501192018'),
 ('20190502145256'),
 ('20190502174401'),
-('20190503140654');
+('20190503140654'),
+('20190503152336');
 
 

--- a/spec/controllers/staff_profiles_controller_spec.rb
+++ b/spec/controllers/staff_profiles_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe StaffProfilesController, type: :controller do
   let(:valid_attributes) do
     { department_id: FactoryBot.create(:department).id,
       user_id: FactoryBot.create(:user).id,
-      supervisor_id: FactoryBot.create(:user).id,
+      supervisor_id: FactoryBot.create(:staff_profile).id,
       biweekly: false }
   end
 
@@ -82,6 +82,7 @@ RSpec.describe StaffProfilesController, type: :controller do
   describe "POST #create" do
     context "with valid params" do
       it "creates a new StaffProfile" do
+        valid_attributes # do this here so the supervisor gets created before we post the data
         expect do
           post :create, params: { staff_profile: valid_attributes }, session: valid_session
         end.to change(StaffProfile, :count).by(1)

--- a/spec/factories/staff_profiles.rb
+++ b/spec/factories/staff_profiles.rb
@@ -5,9 +5,14 @@ FactoryBot.define do
     user { FactoryBot.create(:user) }
     department { FactoryBot.create(:department) }
     biweekly { false }
+    given_name { "Pat#{srand}" }
+    surname { "Doe#{srand}" }
 
     trait :with_supervisor do
-      supervisor { FactoryBot.create(:user) }
+      after(:create) do |profile, _evaluator|
+        profile.supervisor = FactoryBot.create(:staff_profile)
+        profile.save
+      end
     end
   end
 end

--- a/spec/views/staff_profiles/show.html.erb_spec.rb
+++ b/spec/views/staff_profiles/show.html.erb_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "staff_profiles/show", type: :view do
     render
     expect(rendered).to match(/#{staff_profile.user}/)
     expect(rendered).to match(/#{staff_profile.department}/)
-    expect(rendered).to match(/#{staff_profile.supervisor}/)
+    expect(rendered).to include staff_profile.supervisor.to_s
     expect(rendered).to match(/false/)
   end
 end


### PR DESCRIPTION
Previously the supervisor referenced a user.

I noticed this issue while working on the seeding #72 