### PR TITLE
Add simplecov and write it from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ version: 2
 jobs:
   build:
     working_directory: ~/project
-    parallelism: 1
     docker:
       - image: circleci/ruby:2.4.5-node-browsers
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
+---
 version: 2
 jobs:
   build:
+    working_directory: ~/project
     parallelism: 1
     docker:
       - image: circleci/ruby:2.4.5-node-browsers
@@ -18,6 +20,8 @@ jobs:
           POSTGRES_DB: approvals_test
           POSTGRES_PASSWORD: ""
     steps:
+      - attach_workspace:
+          at: '~/project'
       - checkout
 
       - run:
@@ -95,3 +99,32 @@ jobs:
       # Save test results for timing analysis
       - store_test_results:
           path: test_results
+
+      - persist_to_workspace:
+          root: '~/project'
+          paths: '*'
+
+  coverage_report:
+    working_directory: ~/project
+    docker:
+      - image: circleci/ruby:2.4.5-node-browsers
+    steps:
+      - attach_workspace:
+          at: '~/project'
+      - run: gem install simplecov
+      - run:
+          name: Inspect coverage report
+          command: |
+            RAILS_ENV=test ruby ./scripts/report_coverage.rb
+      - store_artifacts:
+          path: ~/project/coverage
+          destination: coverage
+
+workflows:
+  version: 2
+  build_accept:
+    jobs:
+      - build
+      - coverage_report:
+         requires:
+          - build

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", ">= 2.15"
   gem "factory_bot_rails", require: false
+  gem "simplecov", require: false
   gem "webdrivers", "~> 3.0"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
+    docile (1.3.1)
     dotenv (0.7.0)
     erubi (1.8.0)
     execjs (2.7.0)
@@ -104,6 +105,7 @@ GEM
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    json (2.1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -227,6 +229,11 @@ GEM
     selenium-webdriver (3.142.0)
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -294,6 +301,7 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rspec-rails (~> 3.8)
   sass-rails (~> 5.0)
+  simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/scripts/report_coverage.rb
+++ b/scripts/report_coverage.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "simplecov"
+
+class SimpleCovHelper
+  def self.report_coverage(base_dir: "./coverage")
+    SimpleCov.configure do
+      minimum_coverage(90)
+    end
+    new(base_dir: base_dir).inspect_results
+  end
+
+  attr_reader :base_dir
+
+  def initialize(base_dir:)
+    @base_dir = base_dir
+  end
+
+  def results_file
+    Pathname "#{base_dir}/.resultset.json"
+  end
+
+  def inspect_results
+    results = SimpleCov::Result.from_hash(JSON.parse(File.read(results_file)))
+    results.format!
+    covered_percent = results.covered_percent.round(2)
+    return unless covered_percent < SimpleCov.minimum_coverage
+    $stderr.printf("Coverage (%.2f%%) is below the expected minimum coverage (%.2f%%).\n", covered_percent, SimpleCov.minimum_coverage)
+    Kernel.exit SimpleCov::ExitCodes::MINIMUM_COVERAGE
+  end
+end
+
+SimpleCovHelper.report_coverage

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "factory_bot"
+require "simplecov"
+SimpleCov.start "rails"
 
 FactoryBot.find_definitions
 


### PR DESCRIPTION
I set the threshold at 90%; currently I think we have something like 91% coverage. An issue for 100% coverage might be nice; I think it's totally possible especially this early in a project, and once you're there it's easier to maintain.

We can break out the circle checks more. Figgy has 4: build, rubocop, test, and coverage. It's nice to be able to see what's causing problems in a more granular way. We could make a new issue to do this.

Must of this was adapted from Figgy, which parallelized the tests and then has to join the coverage back together. If we ever end up parallelizing the tests more, we can look at how it's done there.

fixes #75 