### PR TITLE
Calculating request status on StateChange save

### DIFF
--- a/app/models/staff_profile.rb
+++ b/app/models/staff_profile.rb
@@ -7,4 +7,8 @@ class StaffProfile < ApplicationRecord
   def to_s
     "#{surname}, #{given_name} (#{user.uid})"
   end
+
+  def department_head?
+    Department.where(head_id: id).count.positive?
+  end
 end

--- a/app/models/state_change.rb
+++ b/app/models/state_change.rb
@@ -2,6 +2,24 @@
 class StateChange < ApplicationRecord
   belongs_to :approver, class_name: "StaffProfile", required: true
   belongs_to :request, required: true
+  before_save :calculate_new_status
 
   accepts_nested_attributes_for :request
+
+  private
+
+    def calculate_new_status
+      request.status = new_status
+      request.save
+    end
+
+    def new_status
+      if (request.status == "reported") && (action == "canceled")
+        "pending_cancelation"
+      elsif request.is_a?(TravelRequest) && (action == "approved") && !approver.department_head?
+        "pending"
+      else
+        action
+      end
+    end
 end

--- a/db/migrate/20190613173252_add_reported_to_state_change_actions.rb
+++ b/db/migrate/20190613173252_add_reported_to_state_change_actions.rb
@@ -1,0 +1,19 @@
+class AddReportedToStateChangeActions < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :state_changes, :action, :boolean
+    execute <<-SQL
+      DROP TYPE request_action;
+      CREATE TYPE request_action AS ENUM ('approved', 'canceled', 'changes_requested', 'denied', 'reported');
+    SQL
+    add_column :state_changes, :action, :request_action
+  end
+
+  def down
+    remove_column :state_changes, :action, :boolean
+    execute <<-SQL
+      DROP TYPE request_action;
+      CREATE TYPE request_action AS ENUM ('approved', 'denied', 'request_changes', 'canceled');
+    SQL
+    add_column :state_changes, :action, :request_action
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -63,9 +63,10 @@ CREATE TYPE public.request_absence_type AS ENUM (
 
 CREATE TYPE public.request_action AS ENUM (
     'approved',
+    'canceled',
+    'changes_requested',
     'denied',
-    'request_changes',
-    'canceled'
+    'reported'
 );
 
 
@@ -764,6 +765,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190612114950'),
 ('20190613143042'),
 ('20190613150050'),
+('20190613173252'),
 ('20190613185106');
 
 

--- a/spec/controllers/state_change_controller_spec.rb
+++ b/spec/controllers/state_change_controller_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe StateChangesController, type: :controller do
     context "with valid params" do
       let(:new_attributes) do
         {
-          action: "request_changes"
+          action: "changes_requested"
         }
       end
 
@@ -106,7 +106,7 @@ RSpec.describe StateChangesController, type: :controller do
         state_change = FactoryBot.create(:state_change)
         put :update, params: { id: state_change.to_param, state_change: new_attributes }, session: valid_session
         state_change.reload
-        expect(state_change.action).to eq "request_changes"
+        expect(state_change.action).to eq "changes_requested"
       end
 
       it "redirects to the state_change" do

--- a/spec/factories/staff_profiles.rb
+++ b/spec/factories/staff_profiles.rb
@@ -21,5 +21,12 @@ FactoryBot.define do
         profile.save
       end
     end
+
+    trait :as_department_head do
+      after(:create) do |profile, _evaluator|
+        profile.department = FactoryBot.create(:department, head: profile)
+        profile.save
+      end
+    end
   end
 end

--- a/spec/models/staff_profile_spec.rb
+++ b/spec/models/staff_profile_spec.rb
@@ -13,4 +13,17 @@ RSpec.describe StaffProfile, type: :model do
   it { is_expected.to respond_to :given_name }
   it { is_expected.to respond_to :surname }
   it { is_expected.to respond_to :email }
+
+  describe "#department_head?" do
+    it "returns false for a regular employee" do
+      expect(staff_profile.department_head?).to be_falsey
+    end
+
+    context "when it is a department head" do
+      subject(:staff_profile) { FactoryBot.create :staff_profile, :as_department_head }
+      it "returns true for a department head" do
+        expect(staff_profile.department_head?).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/models/state_change_spec.rb
+++ b/spec/models/state_change_spec.rb
@@ -10,4 +10,98 @@ RSpec.describe StateChange, type: :model do
     it { is_expected.to respond_to :request_id }
     it { is_expected.to respond_to :action }
   end
+
+  describe "before_save calculate_new_status" do
+    subject(:state_change) { FactoryBot.create :state_change, request: request, action: action, approver: approver }
+    let(:approver) { FactoryBot.create :staff_profile }
+    context "change applied to an absence request" do
+      let(:request) { FactoryBot.create :absence_request }
+
+      context "when stage changes to approved" do
+        let(:action) { "approved" }
+        it "sets the request status to approved when saved" do
+          state_change
+          expect(request.reload.status).to eq("approved")
+        end
+      end
+
+      context "when stage changes to denied" do
+        let(:action) { "denied" }
+        it "sets the request status to denied when saved" do
+          state_change
+          expect(request.reload.status).to eq("denied")
+        end
+      end
+
+      context "when stage changes to reported" do
+        let(:action) { "reported" }
+        it "sets the request status to reported when saved" do
+          state_change
+          expect(request.reload.status).to eq("reported")
+        end
+      end
+
+      context "when stage changes to canceled and it was not already reported" do
+        let(:action) { "canceled" }
+        it "sets the request status to canceled when saved" do
+          state_change
+          expect(request.reload.status).to eq("canceled")
+        end
+      end
+
+      context "when stage changes to canceled and it was already reported" do
+        let(:action) { "canceled" }
+        let(:request) { FactoryBot.create :absence_request, status: "reported" }
+
+        it "sets the request status to pending_cancelation when saved" do
+          state_change
+          expect(request.reload.status).to eq("pending_cancelation")
+        end
+      end
+    end
+    context "change applied to an travel request" do
+      let(:request) { FactoryBot.create :travel_request }
+
+      context "when stage changes to approved and the supervisor is not a department head" do
+        let(:action) { "approved" }
+        it "sets the request status to pending when saved" do
+          state_change
+          expect(request.reload.status).to eq("pending")
+        end
+      end
+
+      context "when stage changes to approved and the supervisor isa department head" do
+        let(:action) { "approved" }
+        let(:approver) { FactoryBot.create :staff_profile, :as_department_head }
+        it "sets the request status to approved when saved" do
+          state_change
+          expect(request.reload.status).to eq("approved")
+        end
+      end
+
+      context "when stage changes to denied" do
+        let(:action) { "denied" }
+        it "sets the request status to denied when saved" do
+          state_change
+          expect(request.reload.status).to eq("denied")
+        end
+      end
+
+      context "when stage changes to request changes" do
+        let(:action) { "changes_requested" }
+        it "sets the request status to changes_requested when saved" do
+          state_change
+          expect(request.reload.status).to eq("changes_requested")
+        end
+      end
+
+      context "when stage changes to canceled" do
+        let(:action) { "canceled" }
+        it "sets the request status to canceled when saved" do
+          state_change
+          expect(request.reload.status).to eq("canceled")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Added reported to state changes
Change request_changes to changes_requested so it would match with the statuses
fixes #112

One thing we may want to change about this is that any department head can be the final approver for a Travel request.  This may be a bug, but it was an easy first blush and seemed relatively reasonable.