### PR TITLE
Convert Request start_time and end_time into strings

### DIFF
--- a/db/migrate/20190614132041_change_request_times_to_strings.rb
+++ b/db/migrate/20190614132041_change_request_times_to_strings.rb
@@ -1,0 +1,6 @@
+class ChangeRequestTimesToStrings < ActiveRecord::Migration[5.2]
+  def change
+    change_column :requests, :start_time, :string
+    change_column :requests, :end_time, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -314,8 +314,8 @@ CREATE TABLE public.requests (
     absence_type public.request_absence_type,
     status public.request_status,
     event_title character varying,
-    start_time time without time zone,
-    end_time time without time zone,
+    start_time character varying,
+    end_time character varying,
     hours_requested numeric
 );
 
@@ -766,6 +766,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190613143042'),
 ('20190613150050'),
 ('20190613173252'),
-('20190613185106');
+('20190613185106'),
+('20190614132041');
 
 


### PR DESCRIPTION
We'll really only be presenting them to users; all calculations will
happen client-side in order to render a "total hours"