### PR TITLE
Adding EventAttendees & AbsentStaff services

### DIFF
--- a/app/services/absent_staff.rb
+++ b/app/services/absent_staff.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class AbsentStaff
+  class << self
+    def list(start_date:, end_date:)
+      absence_requests =
+        AbsenceRequest.where(start_date: start_date..end_date).or(
+          AbsenceRequest.where(end_date: start_date..end_date)
+        ).or(
+          AbsenceRequest.where("start_date <= ? and end_date >= ?", start_date, end_date)
+        )
+
+      absence_requests.map(&:creator)
+    end
+  end
+end

--- a/app/services/event_attendees.rb
+++ b/app/services/event_attendees.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class EventAttendees
+  class << self
+    def list(recurring_event:, event_start_date:, window: 1.week)
+      start_window = event_start_date - window
+      end_window = event_start_date + window
+      event_requests = EventRequest.where(recurring_event: recurring_event, start_date: start_window..end_window)
+      event_requests.map { |event_request| event_request.request.creator }
+    end
+  end
+end

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RequestsController, type: :controller do
 
   let(:other_absence) { FactoryBot.create(:absence_request) }
   let(:other_travel) { FactoryBot.create(:travel_request) }
-  let(:my_absence) { FactoryBot.create(:absence_request, creator: staff_profile) }
+  let(:my_absence) { FactoryBot.create(:absence_request, creator: staff_profile, start_date: Time.zone.tomorrow) }
   let(:my_travel) { FactoryBot.create(:travel_request, creator: staff_profile) }
 
   before do

--- a/spec/services/absent_staff_spec.rb
+++ b/spec/services/absent_staff_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe AbsentStaff, type: :model do
+  let(:jack) { FactoryBot.create :staff_profile, given_name: "Jack" }
+  let(:jill) { FactoryBot.create :staff_profile, given_name: "Jill" }
+  let(:mary) { FactoryBot.create :staff_profile, given_name: "Mary" }
+  let(:peter) { FactoryBot.create :staff_profile, given_name: "Peter" }
+  let(:mary_sick_2020) do
+    start_date = Time.zone.now + 1.year
+    end_date = start_date + 2.days
+    FactoryBot.create :absence_request, creator: mary, start_date: start_date, end_date: end_date
+  end
+  let(:peter_sick_2020) do
+    start_date = Time.zone.now + 1.year
+    end_date = start_date + 2.days
+    FactoryBot.create :absence_request, creator: peter, start_date: start_date, end_date: end_date
+  end
+  let(:mary_sick_2019) do
+    start_date = Time.zone.now
+    end_date = start_date + 2.days
+    FactoryBot.create :absence_request, creator: mary, start_date: start_date, end_date: end_date
+  end
+  let(:jack_vacation_2019) do
+    start_date = Time.zone.now + 2.days
+    end_date = start_date + 4.days
+    FactoryBot.create :absence_request, creator: jack, start_date: start_date, end_date: end_date
+  end
+  let(:jill_vacation_2019) do
+    start_date = Time.zone.now - 3.days
+    end_date = start_date + 4.days
+    FactoryBot.create :absence_request, creator: jill, start_date: start_date, end_date: end_date
+  end
+
+  before do
+    mary_sick_2019
+    jack_vacation_2019
+    jill_vacation_2019
+    mary_sick_2020
+    peter_sick_2020
+  end
+
+  describe "#list" do
+    it "returns absent staff" do
+      expect(AbsentStaff.list(start_date: Time.zone.now, end_date: Time.zone.now + 2.days)).to contain_exactly(mary, jack, jill)
+    end
+
+    it "returns absent staff when window is inside the staff absence" do
+      expect(AbsentStaff.list(start_date: Time.zone.now - 2.days, end_date: Time.zone.now - 1.day)).to contain_exactly(jill)
+    end
+
+    it "returns absent staff when window is around end date of the absence" do
+      expect(AbsentStaff.list(start_date: Time.zone.now + 2.days, end_date: Time.zone.now + 5.days)).to contain_exactly(mary, jack)
+    end
+  end
+end

--- a/spec/services/event_attendees_spec.rb
+++ b/spec/services/event_attendees_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe EventAttendees, type: :model do
+  let(:jack) { FactoryBot.create :staff_profile, given_name: "Jack" }
+  let(:jill) { FactoryBot.create :staff_profile, given_name: "Jill" }
+  let(:mary) { FactoryBot.create :staff_profile, given_name: "Mary" }
+  let(:peter) { FactoryBot.create :staff_profile, given_name: "Peter" }
+  let(:hill) { FactoryBot.create :recurring_event }
+  let(:peppers) { FactoryBot.create :recurring_event }
+  let(:garden) { FactoryBot.create :recurring_event }
+  let(:mary_garden_2020) do
+    start_date = Time.zone.now + 1.year
+    end_date = start_date + 2.days
+    event_request = FactoryBot.build :event_request, recurring_event: garden, start_date: start_date, end_date: end_date
+    FactoryBot.create :travel_request, creator: mary, event_requests: [event_request], start_date: start_date - 1.day, end_date: end_date
+  end
+  let(:mary_garden_2019) do
+    start_date = Time.zone.now
+    end_date = start_date + 3.days
+    event_request = FactoryBot.build :event_request, recurring_event: garden, start_date: start_date, end_date: end_date
+    FactoryBot.create :travel_request, creator: mary, event_requests: [event_request], start_date: start_date - 1.day, end_date: end_date
+  end
+  let(:jill_garden_2018) do
+    start_date = Time.zone.now - 1.year
+    end_date = start_date + 2.days
+    event_request = FactoryBot.build :event_request, recurring_event: garden, start_date: start_date, end_date: end_date
+    FactoryBot.create :travel_request, creator: jill, event_requests: [event_request], start_date: start_date - 1.day, end_date: end_date
+  end
+  let(:peter_peppers_2019) do
+    start_date = Time.zone.now
+    end_date = start_date + 5.days
+    event_request = FactoryBot.build :event_request, recurring_event: peppers, start_date: start_date, end_date: end_date
+    FactoryBot.create :travel_request, creator: peter, event_requests: [event_request], start_date: start_date - 1.day, end_date: end_date
+  end
+  let(:jack_hill_2019) do
+    start_date = Time.zone.now
+    end_date = start_date + 5.days
+    event_request = FactoryBot.build :event_request, recurring_event: hill, start_date: start_date, end_date: end_date
+    FactoryBot.create :travel_request, creator: jack, event_requests: [event_request], start_date: start_date - 1.day, end_date: end_date
+  end
+  let(:jill_hill_2019) do
+    start_date = Time.zone.now
+    end_date = start_date + 5.days
+    event_request = FactoryBot.build :event_request, recurring_event: hill, start_date: start_date, end_date: end_date
+    FactoryBot.create :travel_request, creator: jill, event_requests: [event_request], start_date: start_date - 1.day, end_date: end_date
+  end
+
+  before do
+    jill_garden_2018
+    mary_garden_2019
+    peter_peppers_2019
+    jack_hill_2019
+    jill_hill_2019
+    mary_garden_2020
+  end
+
+  describe "#list" do
+    it "returns attendees" do
+      expect(EventAttendees.list(recurring_event: garden, event_start_date: Time.zone.now)).to contain_exactly(mary)
+      expect(EventAttendees.list(recurring_event: hill, event_start_date: Time.zone.now)).to contain_exactly(jack, jill)
+      expect(EventAttendees.list(recurring_event: peppers, event_start_date: Time.zone.now)).to contain_exactly(peter)
+    end
+
+    context "date is within a week" do
+      it "returns attendees" do
+        expect(EventAttendees.list(recurring_event: garden, event_start_date: Time.zone.now - 5.days)).to contain_exactly(mary)
+        expect(EventAttendees.list(recurring_event: garden, event_start_date: Time.zone.now - 7.days)).to contain_exactly(mary)
+        expect(EventAttendees.list(recurring_event: garden, event_start_date: Time.zone.now + 5.days)).to contain_exactly(mary)
+        expect(EventAttendees.list(recurring_event: garden, event_start_date: Time.zone.now + 7.days)).to contain_exactly(mary)
+      end
+    end
+
+    context "date does not match" do
+      it "returns no attendees" do
+        expect(EventAttendees.list(recurring_event: garden, event_start_date: Time.zone.now - 8.days)).to be_empty
+        expect(EventAttendees.list(recurring_event: garden, event_start_date: Time.zone.now - 1.month)).to be_empty
+        expect(EventAttendees.list(recurring_event: garden, event_start_date: Time.zone.now + 8.days)).to be_empty
+        expect(EventAttendees.list(recurring_event: garden, event_start_date: Time.zone.now + 1.month)).to be_empty
+      end
+    end
+
+    context "changing the window" do
+      it "returns the right attendees" do
+        expect(EventAttendees.list(recurring_event: garden, event_start_date: Time.zone.now - 4.days, window: 5.days)).to contain_exactly(mary)
+        expect(EventAttendees.list(recurring_event: garden, event_start_date: Time.zone.now - 4.days, window: 3.days)).to be_empty
+        expect(EventAttendees.list(recurring_event: garden, event_start_date: Time.zone.now + 4.days, window: 5.days)).to contain_exactly(mary)
+        expect(EventAttendees.list(recurring_event: garden, event_start_date: Time.zone.now + 4.days, window: 3.days)).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
EventAtendees service allows for quering who is attending an event via the recurring event and a date
AbsentStaff service allows for quering who is absent during a time block