### PR TITLE
Decorator provides combined notes and state changes

### DIFF
--- a/app/decorators/request_decorator.rb
+++ b/app/decorators/request_decorator.rb
@@ -54,6 +54,20 @@ class RequestDecorator
     "#{creator.given_name} #{attendance} #{event_title}"
   end
 
+  def notes_and_changes
+    both = notes.to_a
+    both.concat(state_changes.to_a)
+    both = both.sort_by(&:created_at)
+    both.map do |item|
+      title = title_of_item(item)
+      content = item.content if item.is_a? Note
+      {
+        title: title,
+        content: content
+      }
+    end
+  end
+
   private
 
     def date_format
@@ -73,6 +87,14 @@ class RequestDecorator
         created_at
       else
         state_changes.last.created_at
+      end
+    end
+
+    def title_of_item(item)
+      if item.is_a? Note
+        "Notes from #{item.creator.full_name}"
+      else
+        "#{item.action.titleize} by #{item.approver.full_name} on #{item.created_at.strftime(date_format)}"
       end
     end
 end

--- a/app/models/staff_profile.rb
+++ b/app/models/staff_profile.rb
@@ -28,6 +28,10 @@ class StaffProfile < ApplicationRecord
     "#{surname}, #{given_name} (#{user.uid})"
   end
 
+  def full_name
+    "#{given_name} #{surname}"
+  end
+
   def department_head?
     Department.where(head_id: id).count.positive?
   end

--- a/app/services/random_request_generator.rb
+++ b/app/services/random_request_generator.rb
@@ -10,8 +10,8 @@ class RandomRequestGenerator
                                       event_requests_attributes: [event_requests_attributes(recurring_events: recurring_events)],
                                       estimates_attributes: estimates, status: status,
                                       start_date: start_date, end_date: end_date)
-      request = generate_random_state_changes(request)
-      generate_random_note(request, creator)
+      request = generate_random_note(request, creator)
+      generate_random_state_changes(request)
     end
 
     def generate_absence_request(creator:, status: "pending")
@@ -23,8 +23,8 @@ class RandomRequestGenerator
       request = AbsenceRequest.create!(creator: creator, start_date: start_date, end_date: end_date,
                                        absence_type: Request.absence_types.keys.sample, status: status,
                                        hours_requested: hours_requested)
-      request = generate_random_state_changes(request)
-      generate_random_note(request, creator)
+      request = generate_random_note(request, creator)
+      generate_random_state_changes(request)
     end
 
     private

--- a/app/views/absence_requests/show.html.erb
+++ b/app/views/absence_requests/show.html.erb
@@ -16,7 +16,7 @@
         <%= @absence_request.hours_requested%> Hours
 
       </heading>
-      <%=  render partial: "shared/request_note", collection: @absence_request.notes, as: :note %>
+      <%=  render partial: "shared/request_note", collection: @absence_request.notes_and_changes, as: :note %>
     </grid-item>
     <grid-item columns="lg-9 sm-12" :offset="true">
       <text-style variation="strong">Team members absent during this time period</text-style>

--- a/app/views/shared/_request_note.html.erb
+++ b/app/views/shared/_request_note.html.erb
@@ -1,3 +1,2 @@
-<text-style variation="strong">Note from <%= note.creator %></text-style>
-<text-style><%= note.content %></text-style>
-<text-style variation="strong">Submitted|Approved|Denied at <%= note.created_at %></text-style>
+<text-style variation="strong"><%= note[:title] %></text-style>
+<text-style><%= note[:content] %></text-style>

--- a/app/views/travel_requests/show.html.erb
+++ b/app/views/travel_requests/show.html.erb
@@ -43,7 +43,7 @@
   </grid-container>
   <grid-container>
     <grid-item columns="lg-3 sm-12">
-      <%=  render partial: "shared/request_note", collection: @travel_request.notes, as: :note %>
+      <%=  render partial: "shared/request_note", collection: @travel_request.notes_and_changes, as: :note %>
     </grid-item>
     <grid-item columns="lg-9 sm-12" :offset="true">
       <data-table caption="Anticipated Expenses"

--- a/spec/decorators/travel_request_decorator_spec.rb
+++ b/spec/decorators/travel_request_decorator_spec.rb
@@ -177,4 +177,28 @@ RSpec.describe TravelRequestDecorator, type: :model do
       end
     end
   end
+
+  describe "#notes_and_changes" do
+    let(:department_head) { FactoryBot.create(:staff_profile, :as_department_head, given_name: "Department", surname: "Head") }
+    let(:supervisor) { FactoryBot.create(:staff_profile, given_name: "Sally", surname: "Supervisor", department: department_head.department, supervisor: department_head) }
+    let(:staff) { FactoryBot.create(:staff_profile, given_name: "Staff", surname: "Person", department: department_head.department, supervisor: supervisor) }
+    let(:travel_request) do
+      request = FactoryBot.create(:travel_request, creator: staff)
+      request.notes << FactoryBot.build(:note, content: "Please approve", creator: staff)
+      StateChange.create!(request: request, approver: supervisor, action: "approved")
+      request.notes << FactoryBot.build(:note, content: "looks good", creator: supervisor)
+      request.save
+      StateChange.create!(request: request, approver: department_head, action: "approved")
+      request
+    end
+
+    it "returns the combined data" do
+      expect(travel_request_decorator.notes_and_changes).to eq([
+                                                                 { title: "Notes from Staff Person", content: "Please approve" },
+                                                                 { title: "Approved by Sally Supervisor on #{Time.zone.now.strftime('%b %-d, %Y')}", content: nil },
+                                                                 { title: "Notes from Sally Supervisor", content: "looks good" },
+                                                                 { title: "Approved by Department Head on #{Time.zone.now.strftime('%b %-d, %Y')}", content: nil }
+                                                               ])
+    end
+  end
 end

--- a/spec/factories/absence_requests.rb
+++ b/spec/factories/absence_requests.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     absence_type { "vacation" }
 
     trait :with_note do
-      notes { [FactoryBot.build(:note)] }
+      notes { [FactoryBot.build(:note, creator: creator)] }
 
       after(:create) do |request, _evaluator|
         request.notes.first.request_id = request.id

--- a/spec/factories/travel_requests.rb
+++ b/spec/factories/travel_requests.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
 
     trait :with_note_and_estimate do
       estimates { [FactoryBot.build(:estimate)] }
-      notes { [FactoryBot.build(:note)] }
+      notes { [FactoryBot.build(:note, creator: creator)] }
 
       after(:create) do |request, _evaluator|
         request.estimates.each do |estimate|

--- a/spec/models/staff_profile_spec.rb
+++ b/spec/models/staff_profile_spec.rb
@@ -37,4 +37,11 @@ RSpec.describe StaffProfile, type: :model do
       end
     end
   end
+
+  describe "#full_name" do
+    it "returns the staff_profile" do
+      profile = FactoryBot.create(:staff_profile, given_name: "Jane", surname: "Doe")
+      expect(profile.full_name).to eq("Jane Doe")
+    end
+  end
 end

--- a/spec/views/absence_requests/show.html.erb_spec.rb
+++ b/spec/views/absence_requests/show.html.erb_spec.rb
@@ -2,7 +2,8 @@
 require "rails_helper"
 
 RSpec.describe "absence_requests/show", type: :view do
-  let(:absence_request) { AbsenceRequestDecorator.new(FactoryBot.create(:absence_request, :with_note)) }
+  let(:creator) { FactoryBot.create(:staff_profile, given_name: "Sally", surname: "Smith") }
+  let(:absence_request) { AbsenceRequestDecorator.new(FactoryBot.create(:absence_request, :with_note, creator: creator)) }
   before do
     @absence_request = assign(:absence_request, absence_request)
   end
@@ -12,7 +13,8 @@ RSpec.describe "absence_requests/show", type: :view do
     expect(rendered).to include(absence_request.creator.given_name)
     expect(rendered).to match(/#{ absence_request.start_date.to_s}/)
     expect(rendered).to match(/#{ absence_request.end_date.to_s}/)
-    expect(rendered).to match(/wants to take a Vacation/)
+    expect(rendered).to match(/Sally wants to take a Vacation/)
+    expect(rendered).to include("Notes from Sally Smith")
     expect(rendered).to include(absence_request.notes.first.content)
   end
 end

--- a/spec/views/travel_requests/show.html.erb_spec.rb
+++ b/spec/views/travel_requests/show.html.erb_spec.rb
@@ -2,7 +2,8 @@
 require "rails_helper"
 
 RSpec.describe "travel_requests/show", type: :view do
-  let(:travel_request) { FactoryBot.create(:travel_request, :with_note_and_estimate) }
+  let(:creator) { FactoryBot.create(:staff_profile, given_name: "Sally", surname: "Smith") }
+  let(:travel_request) { FactoryBot.create(:travel_request, :with_note_and_estimate, creator: creator) }
   before do
     @travel_request = assign(:travel_request, TravelRequestDecorator.new(travel_request))
   end
@@ -15,7 +16,8 @@ RSpec.describe "travel_requests/show", type: :view do
     expect(rendered).to match(/#{ travel_request.purpose}/)
     expect(rendered).to match(/#{ travel_request.participation}/)
     expect(rendered).to match(/#{ travel_request.travel_category}/)
-    expect(rendered).to match(/wants to attend/)
+    expect(rendered).to match(/Sally wants to attend/)
+    expect(rendered).to include("Notes from Sally Smith")
     expect(rendered).to include(travel_request.notes.first.content)
     expect(rendered).to match(/#{ travel_request.estimates.first.cost_type}/)
     expect(rendered).to match(/#{ travel_request.estimates.first.amount}/)


### PR DESCRIPTION
This is displayed in the notes section of the travel and absence show pages.

I change the order of the note creation in the random generator so it would look better on the page.

The change was made to both the travel and the absence request show pages:

![Screen Shot 2019-08-30 at 8 47 31 AM](https://user-images.githubusercontent.com/1599081/64021839-da0a6c00-cb02-11e9-80fe-cb0331c23dd8.png)

![Screen Shot 2019-08-30 at 8 47 07 AM](https://user-images.githubusercontent.com/1599081/64021841-dc6cc600-cb02-11e9-81a3-29123a2df5c3.png)

