### PR TITLE
Integrating AASM workflow Gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,5 @@ RSpec/DescribeClass:
 
 Metrics/BlockLength:
   Exclude:
-    - 'spec/controllers/travel_requests_controller_spec.rb'
-    - 'spec/controllers/absence_requests_controller_spec.rb'
-    - 'spec/decorators/travel_request_decorator_spec.rb'
+    - 'spec/**/*'
+    - 'lib/tasks/approvals.rake'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,11 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 20
-# Configuration parameters: CountComments, ExcludedMethods.
-Metrics/BlockLength:
-  Max: 148
-
 # Offense count: 21
 # Configuration parameters: Max.
 RSpec/ExampleLength:

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,9 @@ gem "whenever", require: false
 gem "devise"
 gem "omniauth-cas"
 
+# workflow
+gem "aasm"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "bixby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (5.0.6)
+      concurrent-ruby (~> 1.0)
     actioncable (5.2.3)
       actionpack (= 5.2.3)
       nio4r (~> 2.0)
@@ -335,6 +337,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aasm
   bixby
   bootsnap (>= 1.1.0)
   byebug

--- a/app/controllers/state_changes_controller.rb
+++ b/app/controllers/state_changes_controller.rb
@@ -69,7 +69,7 @@ class StateChangesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def state_change_params
-      params.require(:state_change).permit(:approver_id, :request_id, :action,
+      params.require(:state_change).permit(:agent_id, :request_id, :action,
                                            request_attributes: [
                                              :id,
                                              :travel_category,

--- a/app/decorators/request_decorator.rb
+++ b/app/decorators/request_decorator.rb
@@ -94,7 +94,7 @@ class RequestDecorator
       if item.is_a? Note
         "Notes from #{item.creator.full_name}"
       else
-        "#{item.action.titleize} by #{item.approver.full_name} on #{item.created_at.strftime(date_format)}"
+        "#{item.action.titleize} by #{item.agent.full_name} on #{item.created_at.strftime(date_format)}"
       end
     end
 end

--- a/app/models/absence_request.rb
+++ b/app/models/absence_request.rb
@@ -3,7 +3,23 @@
 #  - attributes are defined on Request
 #  - behavior can be defined here
 class AbsenceRequest < Request
+  include AasmConfig
+
   def to_s
     "#{creator} Absence"
+  end
+
+  aasm column: "status" do
+    # add in an additional states pending_cancelation & recorded which are only valid for an absence request
+    state :pending_cancelation
+    state :recorded
+
+    event :record do
+      transitions from: :approved, to: :recorded
+    end
+
+    event :pending_cancel do
+      transitions from: :recorded, to: :pending_cancelation
+    end
   end
 end

--- a/app/models/concerns/aasm_config.rb
+++ b/app/models/concerns/aasm_config.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+#
+# These are the common AASM configuration items for both the Absence and Travel request
+#
+module AasmConfig
+  extend ActiveSupport::Concern
+
+  included do
+    include AASM
+
+    aasm column: "status", enum: true, no_direct_assignment: true do
+      after_all_transitions :log_status_change
+
+      state :pending, initial: true
+      state :canceled
+      state :approved
+      state :denied
+
+      event :approve do
+        transitions from: :pending, to: :approved, guard: :only_supervisor
+      end
+
+      event :deny do
+        transitions from: :pending, to: :denied, guard: :only_supervisor
+      end
+
+      event :cancel do
+        transitions from: [:pending, :approved], to: :canceled, guard: :only_creator
+      end
+    end
+  end
+
+  def log_status_change(agent:)
+    StateChange.create(request: self, agent: agent, action: current_action)
+  end
+
+  def current_action
+    action = aasm.to_state
+    action = :approved if (action == :pending) && ((aasm.current_event == :approve!) || (aasm.current_event == :approve))
+    action
+  end
+
+  def only_department_head(agent:)
+    agent.department_head?
+  end
+
+  def only_supervisor(agent:)
+    in_supervisor_chain(supervisor: creator.supervisor, agent: agent)
+  end
+
+  def only_creator(agent:)
+    creator == agent
+  end
+
+  private
+
+    def in_supervisor_chain(supervisor:, agent:)
+      return false if supervisor.blank?
+
+      agent == supervisor || in_supervisor_chain(supervisor: supervisor.supervisor, agent: agent)
+    end
+end

--- a/app/models/state_change.rb
+++ b/app/models/state_change.rb
@@ -1,25 +1,7 @@
 # frozen_string_literal: true
 class StateChange < ApplicationRecord
-  belongs_to :approver, class_name: "StaffProfile", required: true
+  belongs_to :agent, class_name: "StaffProfile", required: true
   belongs_to :request, required: true
-  before_save :calculate_new_status
 
   accepts_nested_attributes_for :request
-
-  private
-
-    def calculate_new_status
-      request.status = new_status
-      request.save
-    end
-
-    def new_status
-      if (request.status == "recorded") && (action == "canceled")
-        "pending_cancelation"
-      elsif request.is_a?(TravelRequest) && (action == "approved") && !approver.department_head?
-        "pending"
-      else
-        action
-      end
-    end
 end

--- a/app/models/travel_request.rb
+++ b/app/models/travel_request.rb
@@ -3,7 +3,32 @@
 #  - attributes are defined on Request
 #  - behavior can be defined here
 class TravelRequest < Request
+  include AasmConfig
+
   def to_s
     "#{creator}  #{event_requests.first.recurring_event.name}"
+  end
+
+  aasm column: "status" do
+    # add in additional state, changes_requested, which is only valid for a travel request
+    state :changes_requested
+    event :change_request do
+      transitions from: :pending, to: :changes_requested, guard: :only_supervisor
+    end
+
+    event :fix_requested_changes do
+      transitions from: :changes_requested, to: :pending
+    end
+
+    # Redefined the approve event to allow only department heads the ability to make the final approval
+    event :approve do
+      transitions from: :pending, to: :approved, guard: :only_department_head
+      transitions from: :pending, to: :pending, guard: :only_supervisor
+    end
+
+    # Redefine the cancel event to allow cancelation from changes_requested
+    event :cancel do
+      transitions from: [:pending, :approved, :changes_requested], to: :canceled, guard: :only_creator
+    end
   end
 end

--- a/app/views/state_changes/_form.html.erb
+++ b/app/views/state_changes/_form.html.erb
@@ -12,8 +12,8 @@
   <% end %>
 
   <div class="field">
-    <%= form.label :approver_id %>
-    <%= form.text_field :approver_id %>
+    <%= form.label :agent_id %>
+    <%= form.text_field :agent_id %>
   </div>
 
   <div class="field">

--- a/app/views/state_changes/_state_change.json.jbuilder
+++ b/app/views/state_changes/_state_change.json.jbuilder
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
-json.extract! state_change, :id, :approver_id, :request_id, :approved, :created_at, :updated_at
+json.extract! state_change, :id, :agent_id, :request_id, :approved, :created_at, :updated_at
 json.url state_change_url(state_change, format: :json)

--- a/app/views/state_changes/index.html.erb
+++ b/app/views/state_changes/index.html.erb
@@ -5,7 +5,7 @@
 <table>
   <thead>
     <tr>
-      <th>Approver</th>
+      <th>Agent</th>
       <th>Request</th>
       <th>State Change</th>
       <th colspan="3"></th>
@@ -15,7 +15,7 @@
   <tbody>
     <% @state_changes.each do |state_change| %>
       <tr>
-        <td><%= state_change.approver %></td>
+        <td><%= state_change.agent %></td>
         <td><%= state_change.request %></td>
         <td><%= state_change.action %></td>
         <td><%= link_to 'Show', state_change %></td>

--- a/app/views/state_changes/show.html.erb
+++ b/app/views/state_changes/show.html.erb
@@ -2,7 +2,7 @@
 
 <p>
   <strong>State Change:</strong>
-  <%= @state_change.approver %>
+  <%= @state_change.agent %>
 </p>
 
 <p>

--- a/db/migrate/20190918150741_add_pending_cancelation_to_state_change.rb
+++ b/db/migrate/20190918150741_add_pending_cancelation_to_state_change.rb
@@ -1,0 +1,25 @@
+# This migration will cause loss of data in the requests table due to
+#  the fact that columns are being removed
+class AddPendingCanceltaionToStateChange < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :state_changes, :action, :boolean
+    execute <<-SQL
+      DROP TYPE request_action;
+      CREATE TYPE request_action AS ENUM ('approved', 'canceled', 'changes_requested', 'denied', 'recorded', 'pending_cancelation', 'pending');
+    SQL
+    add_column :state_changes, :action, :request_action
+
+    rename_column :state_changes, :approver_id, :agent_id
+  end
+
+  def down
+    remove_column :state_changes, :action, :boolean
+    execute <<-SQL
+      DROP TYPE request_action;
+      CREATE TYPE request_action AS ENUM ('approved', 'canceled', 'changes_requested', 'denied', 'recorded');
+    SQL
+    add_column :state_changes, :action, :request_action
+
+    rename_column :state_changes, agent_id, :approver_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,20 +10,6 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
---
 -- Name: estimate_cost_type; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -67,7 +53,9 @@ CREATE TYPE public.request_action AS ENUM (
     'canceled',
     'changes_requested',
     'denied',
-    'recorded'
+    'recorded',
+    'pending_cancelation',
+    'pending'
 );
 
 
@@ -394,7 +382,7 @@ ALTER SEQUENCE public.staff_profiles_id_seq OWNED BY public.staff_profiles.id;
 
 CREATE TABLE public.state_changes (
     id bigint NOT NULL,
-    approver_id bigint,
+    agent_id bigint,
     request_id bigint,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
@@ -773,6 +761,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190614132041'),
 ('20190718132916'),
 ('20190826190425'),
-('20190827172900');
+('20190827172900'),
+('20190918150741');
 
 

--- a/spec/controllers/state_change_controller_spec.rb
+++ b/spec/controllers/state_change_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe StateChangesController, type: :controller do
   let(:event_request) { FactoryBot.create(:event_request) }
-  let(:approver) { FactoryBot.create(:staff_profile) }
+  let(:agent) { FactoryBot.create(:staff_profile) }
   let(:travel_request) { FactoryBot.create(:travel_request) }
 
   # This should return the minimal set of attributes required to create a valid
@@ -11,7 +11,7 @@ RSpec.describe StateChangesController, type: :controller do
   # adjust the attributes here as well.
   let(:valid_attributes) do
     {
-      approver_id: approver.id,
+      agent_id: agent.id,
       request_id: travel_request.id,
       action: "approved"
     }
@@ -19,7 +19,7 @@ RSpec.describe StateChangesController, type: :controller do
 
   let(:invalid_attributes) do
     {
-      approver_id: nil,
+      agent_id: nil,
       request_id: nil,
       action: "bad"
     }
@@ -125,8 +125,8 @@ RSpec.describe StateChangesController, type: :controller do
             id: travel_request.id,
             travel_category: "business",
             notes_attributes: [{
-              creator_id: approver.id,
-              content: "Approver message"
+              creator_id: agent.id,
+              content: "agent message"
             }],
             event_requests_attributes: [{
               id: travel_request.event_requests.last.id,
@@ -141,7 +141,7 @@ RSpec.describe StateChangesController, type: :controller do
         put :update, params: { id: state_change.to_param, state_change: nested_attributes }, session: valid_session
         state_change.reload
         expect(state_change.request.travel_category).to eq "business"
-        expect(state_change.request.notes.last.content).to eq "Approver message"
+        expect(state_change.request.notes.last.content).to eq "agent message"
         expect(state_change.request.event_requests.first.recurring_event_id).to eq new_recurring_event.id
       end
 

--- a/spec/decorators/request_list_decorator_spec.rb
+++ b/spec/decorators/request_list_decorator_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 require "rails_helper"
-
-# rubocop:disable Metrics/BlockLength
 RSpec.describe RequestListDecorator, type: :model do
   subject(:request_list_decorator) { described_class.new([FactoryBot.create(:absence_request)], params_hash: params_hash) }
   let(:params_hash) { {} }

--- a/spec/factories/absence_requests.rb
+++ b/spec/factories/absence_requests.rb
@@ -2,11 +2,17 @@
 
 FactoryBot.define do
   factory :absence_request do
-    creator { FactoryBot.create(:staff_profile) }
+    creator { FactoryBot.create(:staff_profile, :with_supervisor) }
     start_date { Time.zone.today }
     end_date { Time.zone.tomorrow }
-    status { "pending" }
+    transient do
+      action { nil }
+    end
     absence_type { "vacation" }
+
+    after(:build) do |request, evaluator|
+      fire_event_safely(request: request, action: evaluator.action, agent: request.creator.supervisor) unless evaluator.action.blank?
+    end
 
     trait :with_note do
       notes { [FactoryBot.build(:note, creator: creator)] }

--- a/spec/factories/fire_event_safely.rb
+++ b/spec/factories/fire_event_safely.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+def fire_event_safely(request:, action:, agent:)
+  if action == :record
+    request.approve(agent: agent)
+  elsif action == :pending_cancel
+    request.approve(agent: agent)
+    request.record(agent: agent)
+  elsif action == :cancel
+    agent = request.creator
+  end
+
+  request.aasm.fire(action, agent: agent)
+end

--- a/spec/factories/staff_profiles.rb
+++ b/spec/factories/staff_profiles.rb
@@ -18,6 +18,8 @@ FactoryBot.define do
     trait :with_department do
       after(:create) do |profile, _evaluator|
         profile.department = FactoryBot.create(:department, :with_head)
+        profile.supervisor = FactoryBot.create(:staff_profile) if profile.supervisor.blank?
+        profile.supervisor.supervisor = profile.department.head
         profile.save
       end
     end

--- a/spec/factories/state_changes.rb
+++ b/spec/factories/state_changes.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :state_change do
     request { FactoryBot.create(:travel_request) }
-    approver { FactoryBot.create(:staff_profile) }
+    agent { FactoryBot.create(:staff_profile) }
     action "approved"
   end
 end

--- a/spec/factories/travel_requests.rb
+++ b/spec/factories/travel_requests.rb
@@ -2,11 +2,17 @@
 
 FactoryBot.define do
   factory :travel_request do
-    creator { FactoryBot.create(:staff_profile) }
+    creator { FactoryBot.create(:staff_profile, :with_department) }
     event_requests { [FactoryBot.build(:event_request)] }
     start_date { Time.zone.today }
     end_date { Time.zone.tomorrow }
-    status { "pending" }
+    transient do
+      action { nil }
+    end
+
+    after(:build) do |request, evaluator|
+      fire_event_safely(request: request, action: evaluator.action, agent: request.creator.department.head) unless evaluator.action.blank?
+    end
 
     trait :with_note_and_estimate do
       estimates { [FactoryBot.build(:estimate)] }

--- a/spec/features/my_requests_spec.rb
+++ b/spec/features/my_requests_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.feature "My Requests", type: :feature, js: true do
   let(:user) { FactoryBot.create :user }
-  let(:staff_profile) { FactoryBot.create :staff_profile, user: user }
+  let(:staff_profile) { FactoryBot.create :staff_profile, :with_department, user: user }
 
   before do
     sign_in user
@@ -11,12 +11,12 @@ RSpec.feature "My Requests", type: :feature, js: true do
 
   scenario "I can filter my requests" do
     FactoryBot.create(:absence_request, creator: staff_profile)
-    FactoryBot.create(:absence_request, creator: staff_profile, status: "approved")
+    FactoryBot.create(:absence_request, creator: staff_profile, action: "approve")
     FactoryBot.create(:absence_request, creator: staff_profile, absence_type: "sick")
-    FactoryBot.create(:absence_request, creator: staff_profile, absence_type: "sick", status: "approved")
+    FactoryBot.create(:absence_request, creator: staff_profile, absence_type: "sick", action: "approve")
     FactoryBot.create(:travel_request, creator: staff_profile)
-    FactoryBot.create(:travel_request, creator: staff_profile, status: "approved")
-    FactoryBot.create(:travel_request, creator: staff_profile, status: "approved", travel_category: "professional_development")
+    FactoryBot.create(:travel_request, creator: staff_profile, action: "approve")
+    FactoryBot.create(:travel_request, creator: staff_profile, action: "approve", travel_category: "professional_development")
 
     visit "/my_requests"
     assert_selector "article.lux-card", count: Request.count
@@ -67,9 +67,9 @@ RSpec.feature "My Requests", type: :feature, js: true do
   end
 
   scenario "I can search my requests" do
-    absence_request = FactoryBot.create(:absence_request, creator: staff_profile, status: :approved)
-    absence_request2 = FactoryBot.create(:absence_request, creator: staff_profile, status: :denied)
-    travel_request = FactoryBot.create(:travel_request, creator: staff_profile, status: :approved)
+    absence_request = FactoryBot.create(:absence_request, creator: staff_profile, action: :approve)
+    absence_request2 = FactoryBot.create(:absence_request, creator: staff_profile, action: :deny)
+    travel_request = FactoryBot.create(:travel_request, creator: staff_profile, action: :approve)
     FactoryBot.create(:note, content: "elephants love balloons", request: absence_request)
     FactoryBot.create(:note, content: "elephants love balloons", request: absence_request2)
     FactoryBot.create(:note, content: "flamingoes are pink because of shrimp", request: travel_request)

--- a/spec/models/absence_request_spec.rb
+++ b/spec/models/absence_request_spec.rb
@@ -2,8 +2,9 @@
 require "rails_helper"
 
 RSpec.describe AbsenceRequest, type: :model do
+  subject(:absence_request) { described_class.new }
+  let(:user) { FactoryBot.create :staff_profile, :with_department }
   describe "attributes relevant to absence requests" do
-    subject { described_class.new }
     it { is_expected.to respond_to :absence_type }
     it { is_expected.to respond_to :creator }
     it { is_expected.to respond_to :end_date }
@@ -13,5 +14,204 @@ RSpec.describe AbsenceRequest, type: :model do
     it { is_expected.to respond_to :start_date }
     it { is_expected.to respond_to :start_time }
     it { is_expected.to respond_to :status }
+    it { is_expected.to respond_to :pending? }
+    it { is_expected.to respond_to :canceled? }
+    it { is_expected.to respond_to :approved? }
+    it { is_expected.to respond_to :denied? }
+    it { is_expected.to respond_to :pending_cancelation? }
+    it { is_expected.to respond_to :recorded? }
+  end
+
+  describe "#status" do
+    it "has a default of pending" do
+      expect(absence_request.status).to eq("pending")
+    end
+  end
+
+  context "A saved absence request" do
+    let(:creator) { FactoryBot.create :staff_profile, :with_department }
+    let(:absence_request) { FactoryBot.create :absence_request, creator: creator }
+    let(:supervisor) { creator.supervisor }
+    let(:department_head) { creator.department.head }
+
+    describe "#approve!" do
+      it "approves a pending event if the agent is their supervisor" do
+        expect do
+          absence_request.approve!(agent: supervisor)
+        end.to change(StateChange, :count).by(1)
+        expect(absence_request.status).to eq("approved")
+        expect(absence_request.persisted?).to be_truthy
+      end
+
+      it "approves a pending event if the agent is their department head" do
+        expect do
+          absence_request.approve!(agent: department_head)
+        end.to change(StateChange, :count).by(1)
+        expect(absence_request.status).to eq("approved")
+        expect(absence_request.persisted?).to be_truthy
+      end
+
+      it "Does not approve if the agent is not a supervisor" do
+        expect { absence_request.approve!(agent: user) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not approve a recorded event" do
+        absence_request.approve!(agent: supervisor)
+        absence_request.record!(agent: user)
+        expect { absence_request.approve!(agent: user) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not approve a pending canceled event" do
+        absence_request.approve!(agent: supervisor)
+        absence_request.record!(agent: user)
+        absence_request.pending_cancel!(agent: user)
+        expect { absence_request.approve!(agent: supervisor) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not approve a canceled event" do
+        absence_request.cancel!(agent: creator)
+        expect { absence_request.approve!(agent: supervisor) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not approve a denied event" do
+        absence_request.deny!(agent: supervisor)
+        expect { absence_request.approve!(agent: supervisor) }.to raise_error AASM::InvalidTransition
+      end
+    end
+
+    describe "#deny!" do
+      it "does not deny a pending event if you are not a supervisor of the requestor" do
+        expect { absence_request.deny!(agent: user) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "denies a pending event if the agent is the department head" do
+        expect do
+          absence_request.deny!(agent: department_head)
+        end.to change(StateChange, :count).by(1)
+        expect(absence_request.status).to eq("denied")
+        expect(absence_request.persisted?).to be_truthy
+      end
+
+      it "denies a pending event is the agent is a supervisor" do
+        expect do
+          absence_request.deny!(agent: supervisor)
+        end.to change(StateChange, :count).by(1)
+        expect(absence_request.status).to eq("denied")
+        expect(absence_request.persisted?).to be_truthy
+      end
+
+      it "Does not deny a recorded event" do
+        absence_request.approve!(agent: supervisor)
+        absence_request.record!(agent: user)
+        expect { absence_request.deny!(agent: supervisor) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not deny a pending canceled event" do
+        absence_request.approve!(agent: supervisor)
+        absence_request.record!(agent: user)
+        absence_request.pending_cancel!(agent: user)
+        expect { absence_request.deny!(agent: supervisor) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not deny a canceled event" do
+        absence_request.cancel!(agent: creator)
+        expect { absence_request.deny!(agent: supervisor) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not deny an approved event" do
+        absence_request.approve!(agent: supervisor)
+        expect { absence_request.deny!(agent: supervisor) }.to raise_error AASM::InvalidTransition
+      end
+    end
+
+    describe "#record!" do
+      it "records an approved event" do
+        expect do
+          absence_request.approve!(agent: supervisor)
+          absence_request.record!(agent: user)
+        end.to change(StateChange, :count).by(2)
+        expect(absence_request.status).to eq("recorded")
+        expect(absence_request.persisted?).to be_truthy
+      end
+
+      it "Does not record a pending event" do
+        expect { absence_request.record!(agent: user) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not record a canceled event" do
+        absence_request.cancel!(agent: creator)
+        expect { absence_request.record!(agent: user) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not record a denied event" do
+        absence_request.deny!(agent: supervisor)
+        expect { absence_request.record!(agent: user) }.to raise_error AASM::InvalidTransition
+      end
+    end
+
+    describe "#pending_cancel!" do
+      it "pending cancel a recorded event" do
+        expect do
+          absence_request.approve!(agent: supervisor)
+          absence_request.record!(agent: user)
+          absence_request.pending_cancel!(agent: user)
+        end.to change(StateChange, :count).by(3)
+        expect(absence_request.status).to eq("pending_cancelation")
+        expect(absence_request.persisted?).to be_truthy
+      end
+
+      it "Does not pending cancel a pending event" do
+        expect { absence_request.pending_cancel!(agent: user) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not pending cancel a canceled event" do
+        absence_request.cancel!(agent: creator)
+        expect { absence_request.pending_cancel!(agent: user) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not pending cancel an approved event" do
+        absence_request.approve!(agent: supervisor)
+        expect { absence_request.pending_cancel!(agent: user) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not pending cancel an denied event" do
+        absence_request.deny!(agent: supervisor)
+        expect { absence_request.pending_cancel!(agent: user) }.to raise_error AASM::InvalidTransition
+      end
+    end
+
+    describe "#cancel!" do
+      it "cancels a pending event" do
+        expect do
+          absence_request.cancel!(agent: creator)
+        end.to change(StateChange, :count).by(1)
+        expect(absence_request.status).to eq("canceled")
+        expect(absence_request.persisted?).to be_truthy
+      end
+
+      it "cancels an approved event" do
+        expect do
+          absence_request.approve!(agent: supervisor)
+          absence_request.cancel!(agent: creator)
+        end.to change(StateChange, :count).by(2)
+        expect(absence_request.status).to eq("canceled")
+        expect(absence_request.persisted?).to be_truthy
+      end
+
+      it "does not cancel a recorded event" do
+        absence_request.approve!(agent: supervisor)
+        absence_request.record!(agent: user)
+        expect { absence_request.cancel!(agent: user) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "does not cancel an event if it is not the creator requesting" do
+        expect { absence_request.cancel!(agent: supervisor) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "does not cancel a denied event" do
+        absence_request.deny!(agent: supervisor)
+        expect { absence_request.cancel!(agent: user) }.to raise_error AASM::InvalidTransition
+      end
+    end
   end
 end

--- a/spec/models/state_change_spec.rb
+++ b/spec/models/state_change_spec.rb
@@ -4,104 +4,10 @@ require "rails_helper"
 RSpec.describe StateChange, type: :model do
   describe "attributes relevant to state_change" do
     subject(:state_change) { described_class.new }
-    it { is_expected.to respond_to :approver_id }
-    it { is_expected.to respond_to :approver }
+    it { is_expected.to respond_to :agent_id }
+    it { is_expected.to respond_to :agent }
     it { is_expected.to respond_to :request }
     it { is_expected.to respond_to :request_id }
     it { is_expected.to respond_to :action }
-  end
-
-  describe "before_save calculate_new_status" do
-    subject(:state_change) { FactoryBot.create :state_change, request: request, action: action, approver: approver }
-    let(:approver) { FactoryBot.create :staff_profile }
-    context "change applied to an absence request" do
-      let(:request) { FactoryBot.create :absence_request }
-
-      context "when stage changes to approved" do
-        let(:action) { "approved" }
-        it "sets the request status to approved when saved" do
-          state_change
-          expect(request.reload.status).to eq("approved")
-        end
-      end
-
-      context "when stage changes to denied" do
-        let(:action) { "denied" }
-        it "sets the request status to denied when saved" do
-          state_change
-          expect(request.reload.status).to eq("denied")
-        end
-      end
-
-      context "when stage changes to recorded" do
-        let(:action) { "recorded" }
-        it "sets the request status to recorded when saved" do
-          state_change
-          expect(request.reload.status).to eq("recorded")
-        end
-      end
-
-      context "when stage changes to canceled and it was not already recorded" do
-        let(:action) { "canceled" }
-        it "sets the request status to canceled when saved" do
-          state_change
-          expect(request.reload.status).to eq("canceled")
-        end
-      end
-
-      context "when stage changes to canceled and it was already recorded" do
-        let(:action) { "canceled" }
-        let(:request) { FactoryBot.create :absence_request, status: "recorded" }
-
-        it "sets the request status to pending_cancelation when saved" do
-          state_change
-          expect(request.reload.status).to eq("pending_cancelation")
-        end
-      end
-    end
-    context "change applied to an travel request" do
-      let(:request) { FactoryBot.create :travel_request }
-
-      context "when stage changes to approved and the supervisor is not a department head" do
-        let(:action) { "approved" }
-        it "sets the request status to pending when saved" do
-          state_change
-          expect(request.reload.status).to eq("pending")
-        end
-      end
-
-      context "when stage changes to approved and the supervisor isa department head" do
-        let(:action) { "approved" }
-        let(:approver) { FactoryBot.create :staff_profile, :as_department_head }
-        it "sets the request status to approved when saved" do
-          state_change
-          expect(request.reload.status).to eq("approved")
-        end
-      end
-
-      context "when stage changes to denied" do
-        let(:action) { "denied" }
-        it "sets the request status to denied when saved" do
-          state_change
-          expect(request.reload.status).to eq("denied")
-        end
-      end
-
-      context "when stage changes to request changes" do
-        let(:action) { "changes_requested" }
-        it "sets the request status to changes_requested when saved" do
-          state_change
-          expect(request.reload.status).to eq("changes_requested")
-        end
-      end
-
-      context "when stage changes to canceled" do
-        let(:action) { "canceled" }
-        it "sets the request status to canceled when saved" do
-          state_change
-          expect(request.reload.status).to eq("canceled")
-        end
-      end
-    end
   end
 end

--- a/spec/models/travel_request_spec.rb
+++ b/spec/models/travel_request_spec.rb
@@ -15,5 +15,168 @@ RSpec.describe TravelRequest, type: :model do
     it { is_expected.to respond_to :start_date }
     it { is_expected.to respond_to :status }
     it { is_expected.to respond_to :travel_category }
+    it { is_expected.to respond_to :pending? }
+    it { is_expected.to respond_to :canceled? }
+    it { is_expected.to respond_to :approved? }
+    it { is_expected.to respond_to :denied? }
+    it { is_expected.to respond_to :changes_requested? }
+  end
+
+  describe "#status" do
+    it "has a default of pending" do
+      expect(travel_request.status).to eq("pending")
+    end
+  end
+
+  context "A saved absence request" do
+    let(:user) { FactoryBot.create :staff_profile, :with_department }
+    let(:travel_request) { FactoryBot.create :travel_request, creator: user }
+    let(:supervisor) { user.supervisor }
+    let(:department_head) { user.department.head }
+
+    describe "#approve!" do
+      it "does not approve a pending event unless the approver is a department head" do
+        expect do
+          travel_request.approve!(agent: supervisor)
+        end.to change(StateChange, :count).by(1)
+
+        expect(travel_request.status).to eq("pending")
+        expect(travel_request.persisted?).to be_truthy
+      end
+
+      it "approves a pending event when the approver is a department head" do
+        expect do
+          travel_request.approve!(agent: department_head)
+        end.to change(StateChange, :count).by(1)
+        expect(travel_request.status).to eq("approved")
+        expect(travel_request.persisted?).to be_truthy
+      end
+
+      it "does not approve a pending event unless the approver is a supervisor" do
+        expect { travel_request.approve!(agent: user) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not approve a change_request event" do
+        travel_request.change_request!(agent: supervisor)
+        expect { travel_request.approve!(agent: supervisor) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not approve a canceled event" do
+        travel_request.cancel!(agent: user)
+        expect { travel_request.approve!(agent: supervisor) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not approve a denied event" do
+        travel_request.deny!(agent: supervisor)
+        expect { travel_request.approve!(agent: supervisor) }.to raise_error AASM::InvalidTransition
+      end
+    end
+
+    describe "#deny!" do
+      it "denies a pending event if the agent is their supervisor" do
+        expect do
+          travel_request.deny!(agent: supervisor)
+        end.to change(StateChange, :count).by(1)
+        expect(travel_request.status).to eq("denied")
+        expect(travel_request.persisted?).to be_truthy
+      end
+
+      it "denies a pending event if the agent is their department head" do
+        expect do
+          travel_request.deny!(agent: department_head)
+        end.to change(StateChange, :count).by(1)
+        expect(travel_request.status).to eq("denied")
+        expect(travel_request.persisted?).to be_truthy
+      end
+
+      it "Does not deny an event if the agent is not a supervisor" do
+        expect { travel_request.deny!(agent: user) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not deny a change_request event" do
+        travel_request.change_request!(agent: supervisor)
+        expect { travel_request.deny!(agent: supervisor) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not deny a canceled event" do
+        travel_request.cancel!(agent: user)
+        expect { travel_request.deny!(agent: supervisor) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not deny an approved event" do
+        travel_request.approve!(agent: user.department.head)
+        expect { travel_request.deny!(agent: supervisor) }.to raise_error AASM::InvalidTransition
+      end
+    end
+
+    describe "#change_request!" do
+      it "records a change_request event if the requestor is their supervisor" do
+        expect do
+          travel_request.change_request!(agent: supervisor)
+        end.to change(StateChange, :count).by(1)
+        expect(travel_request.status).to eq("changes_requested")
+        expect(travel_request.persisted?).to be_truthy
+      end
+
+      it "records a change_request event if the requestor is their department head" do
+        expect do
+          travel_request.change_request!(agent: department_head)
+        end.to change(StateChange, :count).by(1)
+        expect(travel_request.status).to eq("changes_requested")
+        expect(travel_request.persisted?).to be_truthy
+      end
+
+      it "Does not change_request if the requestor is not their supervisor" do
+        expect { travel_request.change_request!(agent: user) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not change_request an approved event" do
+        travel_request.approve!(agent: user.department.head)
+        expect { travel_request.change_request!(agent: supervisor) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not change_request a canceled event" do
+        travel_request.cancel!(agent: user)
+        expect { travel_request.change_request!(agent: supervisor) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "Does not change_request a denied event" do
+        travel_request.deny!(agent: supervisor)
+        expect { travel_request.change_request!(agent: supervisor) }.to raise_error AASM::InvalidTransition
+      end
+    end
+
+    describe "#cancel!" do
+      it "cancels a pending event" do
+        expect do
+          travel_request.cancel!(agent: user)
+        end.to change(StateChange, :count).by(1)
+        expect(travel_request.status).to eq("canceled")
+        expect(travel_request.persisted?).to be_truthy
+      end
+
+      it "cancels an approved event" do
+        travel_request.approve!(agent: user.department.head)
+        travel_request.cancel!(agent: user)
+        expect(travel_request.status).to eq("canceled")
+        expect(travel_request.persisted?).to be_truthy
+      end
+
+      it "cancels a change_request event" do
+        travel_request.change_request!(agent: supervisor)
+        travel_request.cancel!(agent: user)
+        expect(travel_request.status).to eq("canceled")
+        expect(travel_request.persisted?).to be_truthy
+      end
+
+      it "does not cancel a denied event" do
+        travel_request.deny!(agent: supervisor)
+        expect { travel_request.cancel!(agent: user) }.to raise_error AASM::InvalidTransition
+      end
+
+      it "does not cancel an pending event if it is not the creator requesting the event" do
+        expect { travel_request.cancel!(agent: supervisor) }.to raise_error AASM::InvalidTransition
+      end
+    end
   end
 end

--- a/spec/services/random_request_generator_spec.rb
+++ b/spec/services/random_request_generator_spec.rb
@@ -56,9 +56,9 @@ RSpec.describe RandomRequestGenerator, type: :model do
         expect(request.status).to eq("approved")
         expect(request.creator).to eq(creator)
         expect(request.travel_category).not_to be_blank
-        expect(request.state_changes.first.approver).to eq(creator.supervisor)
+        expect(request.state_changes.first.agent).to eq(creator.supervisor)
         expect(request.state_changes.count).to eq(2)
-        expect(request.state_changes.last.approver).to eq(creator.department.head)
+        expect(request.state_changes.last.agent).to eq(creator.department.head)
         expect(request.notes.count).to eq(1)
       end
     end
@@ -74,7 +74,7 @@ RSpec.describe RandomRequestGenerator, type: :model do
         expect(request.start_date).not_to be_blank
         expect(request.end_date).not_to be_blank
         expect(request.status).to eq("approved")
-        expect(request.state_changes.first.approver).to eq(creator.supervisor)
+        expect(request.state_changes.first.agent).to eq(creator.supervisor)
         expect(request.state_changes.count).to eq(1)
         expect(request.notes.count).to eq(1)
       end
@@ -93,7 +93,7 @@ RSpec.describe RandomRequestGenerator, type: :model do
         expect(request.end_date).not_to be_blank
         expect(request.status).to eq("denied")
         expect(request.creator).to eq(creator)
-        expect(request.state_changes.first.approver).to eq(creator.supervisor)
+        expect(request.state_changes.first.agent).to eq(creator.supervisor)
         expect(request.state_changes.first.action).to eq("denied")
         expect(request.state_changes.count).to eq(1)
         expect(request.notes.count).to eq(2)
@@ -111,7 +111,7 @@ RSpec.describe RandomRequestGenerator, type: :model do
         expect(request.start_date).not_to be_blank
         expect(request.end_date).not_to be_blank
         expect(request.status).to eq("denied")
-        expect(request.state_changes.first.approver).to eq(creator.supervisor)
+        expect(request.state_changes.first.agent).to eq(creator.supervisor)
         expect(request.state_changes.first.action).to eq("denied")
         expect(request.state_changes.count).to eq(1)
         expect(request.notes.count).to eq(2)

--- a/spec/views/state_changes/edit.html.erb_spec.rb
+++ b/spec/views/state_changes/edit.html.erb_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "state_changes/edit", type: :view do
     render
 
     assert_select "form[action=?][method=?]", state_change_path(state_change), "post" do
-      assert_select "input[name=?][value=?]", "state_change[approver_id]", state_change.approver_id.to_s
+      assert_select "input[name=?][value=?]", "state_change[agent_id]", state_change.agent_id.to_s
 
       assert_select "input[name=?][value=?]", "state_change[request_id]", state_change.request_id.to_s
 

--- a/spec/views/state_changes/index.html.erb_spec.rb
+++ b/spec/views/state_changes/index.html.erb_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe "state_changes/index", type: :view do
 
   it "renders a list of state_changes" do
     render
-    assert_select "tr>td", text: state_change1.approver.to_s, count: 1
-    assert_select "tr>td", text: state_change2.approver.to_s, count: 1
+    assert_select "tr>td", text: state_change1.agent.to_s, count: 1
+    assert_select "tr>td", text: state_change2.agent.to_s, count: 1
     assert_select "tr>td", text: state_change2.request.to_s, count: 1
     assert_select "tr>td", text: state_change2.request.to_s, count: 1
     assert_select "tr>td", text: state_change2.action.to_s, count: 2

--- a/spec/views/state_changes/new.html.erb_spec.rb
+++ b/spec/views/state_changes/new.html.erb_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe "state_changes/new", type: :view do
-  let(:state_change) { StateChange.new(approver: nil, request: nil, action: "denied") }
+  let(:state_change) { StateChange.new(agent: nil, request: nil, action: "denied") }
   before do
     assign(:state_change, state_change)
   end
@@ -11,7 +11,7 @@ RSpec.describe "state_changes/new", type: :view do
     render
 
     assert_select "form[action=?][method=?]", state_changes_path, "post" do
-      assert_select "input[name=?]", "state_change[approver_id]"
+      assert_select "input[name=?]", "state_change[agent_id]"
 
       assert_select "input[name=?]", "state_change[request_id]"
 

--- a/spec/views/state_changes/show.html.erb_spec.rb
+++ b/spec/views/state_changes/show.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "state_changes/show", type: :view do
 
   it "renders attributes in <p>" do
     render
-    expect(rendered).to include(state_change.approver.to_s)
+    expect(rendered).to include(state_change.agent.to_s)
     expect(rendered).to include(state_change.request.to_s)
     expect(rendered).to include(state_change.action.to_s)
   end


### PR DESCRIPTION

Travel and Absence Requests now have events that can be used to move the request through the work flow

At this point State Change has been moved into the workflow so that a StateChange object gets created each time a transition occurs.

needed to add pending and pending_cancelation to state change since those are valid changes

Additional callbacks (https://github.com/aasm/aasm#callbacks) could be used to send out notifications
Additional guards (https://github.com/aasm/aasm#guards) could be used to monitor who can move a request from state to state.

Additionally renamed StateChange approver to agent