### PR TITLE
AbsenceRequest and TravelRequest Validation

### DIFF
--- a/app/models/absence_request.rb
+++ b/app/models/absence_request.rb
@@ -22,4 +22,54 @@ class AbsenceRequest < Request
       transitions from: :recorded, to: :pending_cancelation
     end
   end
+
+  ##########  Invalid Attributes ###########
+  # Because we are using single table inheritance there are a number of fields in a Request
+  # that are only valid for a travel request.
+  # The methods below force an invalid attribute error if someone tries to access them
+
+  # participation is not a valid property of a AbsenceRequest
+  def participation=(*_args)
+    raise_invalid_argument(property_name: :participation)
+  end
+
+  def participation
+    raise_invalid_argument(property_name: :participation)
+  end
+
+  # purpose is not a valid property of a AbsenceRequest
+  def purpose=(*_args)
+    raise_invalid_argument(property_name: :purpose)
+  end
+
+  def purpose
+    raise_invalid_argument(property_name: :purpose)
+  end
+
+  # estimates is not a valid property of a AbsenceRequest
+  def estimates=(*_args)
+    raise_invalid_argument(property_name: :estimates)
+  end
+
+  def estimates
+    raise_invalid_argument(property_name: :estimates)
+  end
+
+  # event_requests is not a valid property of a AbsenceRequest
+  def event_requests=(*_args)
+    raise_invalid_argument(property_name: :event_requests)
+  end
+
+  def event_requests
+    raise_invalid_argument(property_name: :event_requests)
+  end
+
+  # travel_category is not a valid property of a AbsenceRequest
+  def travel_category=(*_args)
+    raise_invalid_argument(property_name: :travel_category)
+  end
+
+  def travel_category
+    raise_invalid_argument(property_name: :travel_category)
+  end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -72,4 +72,10 @@ class Request < ApplicationRecord
 
   # use request_type as the single table inheritance flag
   self.inheritance_column = "request_type"
+
+  private
+
+    def raise_invalid_argument(property_name:)
+      raise ActiveModel::UnknownAttributeError.new(self, property_name)
+    end
 end

--- a/app/models/travel_request.rb
+++ b/app/models/travel_request.rb
@@ -31,4 +31,45 @@ class TravelRequest < Request
       transitions from: [:pending, :approved, :changes_requested], to: :canceled, guard: :only_creator
     end
   end
+
+  ##########  Invalid Attributes ###########
+  # Because we are using single table inheritance there are a number of fields in a Request
+  # that are only valid for a absence request.
+  # The methods below force an invalid attribute error if someone tries to access them
+
+  # absence_type is not a valid property of a TravelRequest
+  def absence_type=(*_args)
+    raise_invalid_argument(property_name: :absence_type)
+  end
+
+  def absence_type
+    raise_invalid_argument(property_name: :absence_type)
+  end
+
+  # hours_requested is not a valid property of a TravelRequest
+  def hours_requested=(*_args)
+    raise_invalid_argument(property_name: :hours_requested)
+  end
+
+  def hours_requested
+    raise_invalid_argument(property_name: :hours_requested)
+  end
+
+  # end_time is not a valid property of a TravelRequest
+  def end_time=(*_args)
+    raise_invalid_argument(property_name: :end_time)
+  end
+
+  def end_time
+    raise_invalid_argument(property_name: :end_time)
+  end
+
+  # start_time is not a valid property of a TravelRequest
+  def start_time=(*_args)
+    raise_invalid_argument(property_name: :start_time)
+  end
+
+  def start_time
+    raise_invalid_argument(property_name: :start_time)
+  end
 end

--- a/spec/models/absence_request_spec.rb
+++ b/spec/models/absence_request_spec.rb
@@ -214,4 +214,56 @@ RSpec.describe AbsenceRequest, type: :model do
       end
     end
   end
+
+  context "invalid attributes" do
+    it "can not assign participation" do
+      expect { absence_request.participation = "presenter" }.to raise_error ActiveModel::UnknownAttributeError
+    end
+    it "can not request participation" do
+      expect { absence_request.participation }.to raise_error ActiveModel::UnknownAttributeError
+    end
+    it "can assing participation in new" do
+      expect { AbsenceRequest.new(participation: "presenter") }.to raise_error ActiveModel::UnknownAttributeError
+    end
+
+    it "can not assign purpose" do
+      expect { absence_request.purpose = "My grand purpose" }.to raise_error ActiveModel::UnknownAttributeError
+    end
+    it "can not request purpose" do
+      expect { absence_request.purpose }.to raise_error ActiveModel::UnknownAttributeError
+    end
+    it "can assing purpose in new" do
+      expect { AbsenceRequest.new(purpose: "My grand purpose") }.to raise_error ActiveModel::UnknownAttributeError
+    end
+
+    it "can not assign estimates" do
+      expect { absence_request.estimates = [Estimate.new] }.to raise_error ActiveModel::UnknownAttributeError
+    end
+    it "can not request estimates" do
+      expect { absence_request.estimates }.to raise_error ActiveModel::UnknownAttributeError
+    end
+    it "can assing estimates in new" do
+      expect { AbsenceRequest.new(estimates: [Estimate.new]) }.to raise_error ActiveModel::UnknownAttributeError
+    end
+
+    it "can not assign event_requests" do
+      expect { absence_request.event_requests = [EventRequest.new] }.to raise_error ActiveModel::UnknownAttributeError
+    end
+    it "can not request event_requests" do
+      expect { absence_request.event_requests }.to raise_error ActiveModel::UnknownAttributeError
+    end
+    it "can assing event_requests in new" do
+      expect { AbsenceRequest.new(event_requests: [EventRequest.new]) }.to raise_error ActiveModel::UnknownAttributeError
+    end
+
+    it "can not assign travel_category" do
+      expect { absence_request.travel_category = "business" }.to raise_error ActiveModel::UnknownAttributeError
+    end
+    it "can not request travel_category" do
+      expect { absence_request.travel_category }.to raise_error ActiveModel::UnknownAttributeError
+    end
+    it "can assing travel_category in new" do
+      expect { AbsenceRequest.new(travel_category: "business") }.to raise_error ActiveModel::UnknownAttributeError
+    end
+  end
 end

--- a/spec/models/travel_request_spec.rb
+++ b/spec/models/travel_request_spec.rb
@@ -179,4 +179,46 @@ RSpec.describe TravelRequest, type: :model do
       end
     end
   end
+
+  context "invalid attributes" do
+    it "can not assign absence_type" do
+      expect { travel_request.absence_type = "vacation" }.to raise_error ActiveModel::UnknownAttributeError
+    end
+    it "can not request absence_type" do
+      expect { travel_request.absence_type }.to raise_error ActiveModel::UnknownAttributeError
+    end
+    it "can assing absence_type in new" do
+      expect { TravelRequest.new(absence_type: "vacation") }.to raise_error ActiveModel::UnknownAttributeError
+    end
+
+    it "can not assign hours_requested" do
+      expect { travel_request.hours_requested = 40 }.to raise_error ActiveModel::UnknownAttributeError
+    end
+    it "can not request hours_requested" do
+      expect { travel_request.hours_requested }.to raise_error ActiveModel::UnknownAttributeError
+    end
+    it "can assing hours_requested in new" do
+      expect { TravelRequest.new(hours_requested: 40) }.to raise_error ActiveModel::UnknownAttributeError
+    end
+
+    it "can not assign end_time" do
+      expect { travel_request.end_time = "10:00pm" }.to raise_error ActiveModel::UnknownAttributeError
+    end
+    it "can not request end_time" do
+      expect { travel_request.end_time }.to raise_error ActiveModel::UnknownAttributeError
+    end
+    it "can assing end_time in new" do
+      expect { TravelRequest.new(end_time: "10:00pm") }.to raise_error ActiveModel::UnknownAttributeError
+    end
+
+    it "can not assign start_time" do
+      expect { travel_request.start_time = "10:00pm" }.to raise_error ActiveModel::UnknownAttributeError
+    end
+    it "can not request start_time" do
+      expect { travel_request.start_time }.to raise_error ActiveModel::UnknownAttributeError
+    end
+    it "can assing start_time in new" do
+      expect { TravelRequest.new(start_time: "10:00pm") }.to raise_error ActiveModel::UnknownAttributeError
+    end
+  end
 end

--- a/spec/views/absence_requests/edit.html.erb_spec.rb
+++ b/spec/views/absence_requests/edit.html.erb_spec.rb
@@ -3,8 +3,7 @@ require "rails_helper"
 
 RSpec.describe "absence_requests/edit", type: :view do
   let(:absence_request) do
-    FactoryBot.create(:absence_request, purpose: "my grand purpose",
-                                        absence_type: "vacation")
+    FactoryBot.create(:absence_request, absence_type: "vacation")
   end
   before do
     assign(:absence_request_change_set, AbsenceRequestChangeSet.new(absence_request, start_date: Date.parse("2019-12-23"), end_date: Date.parse("2019-12-27")))

--- a/spec/views/absence_requests/new.html.erb_spec.rb
+++ b/spec/views/absence_requests/new.html.erb_spec.rb
@@ -3,8 +3,7 @@ require "rails_helper"
 
 RSpec.describe "absence_requests/new", type: :view do
   let(:absence_request) do
-    FactoryBot.build(:absence_request, purpose: "my grand purpose",
-                                       absence_type: "vacation")
+    FactoryBot.build(:absence_request, absence_type: "vacation")
   end
   before do
     assign(:absence_request_change_set, AbsenceRequestChangeSet.new(absence_request, start_date: Date.parse("2019-12-23"), end_date: Date.parse("2019-12-27")))


### PR DESCRIPTION
Because we are using single table inheritance there are a number of fields in a Request that are only valid for a travel request or an absence request.

This PR forces the AbsenceRequest or TravelRequest to disallow access to the fields that do not make sense for them.