### PR TITLE
Adds a more visually distinct status tag to requests

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -23,6 +23,10 @@
    background-color: #f9f8f4;
  }
 
+ .main-content {
+   padding-top: 1rem;
+ }
+
  .stretch-height {
    height: calc(100vh - 88px);
    text-align: center;
@@ -30,9 +34,31 @@
 
  .lux-card-content .small,
  .lux-card-header .default {
-   color: gray;
+   color: rgb(65, 70, 78);
+ }
+
+ .lux-card-media {
+   flex-basis: 85px;
+ }
+
+ .lux-card-header {
+   flex-basis: calc(100% - 90px);
  }
 
  .lux-card-content .lux-tag .lux-tag-item {
    margin: 0;
+ }
+
+ 
+ @media (max-width: 599px) {
+  .my-request .full-width .lux-card-content {
+    margin-left: 90px;
+    padding: 0 0 1rem;
+    width: 100%;
+  }
+
+  .my-request .lux-tag.end {
+    float: left;
+    margin-right: 1rem;
+  }
  }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -27,3 +27,12 @@
    height: calc(100vh - 88px);
    text-align: center;
  }
+
+ .lux-card-content .small,
+ .lux-card-header .default {
+   color: gray;
+ }
+
+ .lux-card-content .lux-tag .lux-tag-item {
+   margin: 0;
+ }

--- a/app/decorators/request_decorator.rb
+++ b/app/decorators/request_decorator.rb
@@ -9,11 +9,11 @@ class RequestDecorator
   end
 
   def latest_status
-    "#{decorated_status}"
+    decorated_status.to_s
   end
 
   def latest_status_date
-    "Last Updated on #{date_of_status.strftime(date_format)}"
+    "Updated on #{date_of_status.strftime(date_format)}"
   end
 
   def status_color

--- a/app/decorators/request_decorator.rb
+++ b/app/decorators/request_decorator.rb
@@ -9,18 +9,35 @@ class RequestDecorator
   end
 
   def latest_status
-    "#{decorated_status} on #{date_of_status.strftime(date_format)}"
+    "#{decorated_status}"
+  end
+
+  def latest_status_date
+    "Last Updated on #{date_of_status.strftime(date_format)}"
+  end
+
+  def status_color
+    color_map = {
+      "pending" => "yellow",
+      "approved" => "green",
+      "denied" => "red",
+      "changes_requested" => "yellow",
+      "canceled" => "gray",
+      "recorded" => "green",
+      "pending_cancelation" => "yellow"
+    }
+    color_map[status]
   end
 
   def status_icon
     icon_map = {
-      "pending" => "lux-icon-clock",
-      "approved" => "lux-icon-approved",
-      "denied" => "lux-icon-denied",
-      "changes_requested" => "lux-icon-refresh",
-      "canceled" => "lux-icon-alert",
-      "recorded" => "lux-icon-reported",
-      "pending_cancelation" => "lux-icon-remove"
+      "pending" => "clock",
+      "approved" => "approved",
+      "denied" => "denied",
+      "changes_requested" => "refresh",
+      "canceled" => "alert",
+      "recorded" => "reported",
+      "pending_cancelation" => "remove"
     }
     icon_map[status]
   end

--- a/app/views/absence_requests/_index_detail.html.erb
+++ b/app/views/absence_requests/_index_detail.html.erb
@@ -3,6 +3,7 @@
     <lux-icon-base
       width="50"
       height="50"
+      icon-color="rgb(65, 70, 78)"
     ><<%= absence_request.absence_type_icon %> /></lux-icon-base>
   </card-media>
   <card-header>
@@ -11,9 +12,10 @@
   </card-header>
   <card-content>
     <tag type="tag" :tag-items="[
-      {name: '<%= absence_request.latest_status %>', color: '<%= absence_request.status_color %>', icon: '<%= absence_request.status_icon %>'}
+      {name: '<%= absence_request.latest_status %>', color: '<%= absence_request.status_color %>'}
       ]"
-      horizontal="end"></tag>
+      horizontal="end"
+      size="small"></tag>
     <text-style type="span" variation="small"><%= absence_request.latest_status_date %></text-style>
   </card-content>
 </card>

--- a/app/views/absence_requests/_index_detail.html.erb
+++ b/app/views/absence_requests/_index_detail.html.erb
@@ -10,9 +10,10 @@
     <text-style><%= absence_request.formatted_start_date %> to <%= absence_request.formatted_end_date %></text-style>
   </card-header>
   <card-content>
-    <text-style type="span" variation="small"><lux-icon-base
-      width="14"
-      height="14"
-    ><<%= absence_request.status_icon %>/></lux-icon-base><%= absence_request.latest_status %></text-style>
+    <tag type="tag" :tag-items="[
+      {name: '<%= absence_request.latest_status %>', color: '<%= absence_request.status_color %>', icon: '<%= absence_request.status_icon %>'}
+      ]"
+      horizontal="end"></tag>
+    <text-style type="span" variation="small"><%= absence_request.latest_status_date %></text-style>
   </card-content>
 </card>

--- a/app/views/absence_requests/edit.html.erb
+++ b/app/views/absence_requests/edit.html.erb
@@ -1,4 +1,4 @@
-<wrapper>
+<wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="lg-12 sm-12">
       <heading level="h1" size="h2">Edit Leave Request</heading>

--- a/app/views/absence_requests/new.html.erb
+++ b/app/views/absence_requests/new.html.erb
@@ -1,4 +1,4 @@
-<wrapper>
+<wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="lg-12 sm-12">
       <heading level="h1" size="h2">New Leave Request</heading>

--- a/app/views/absence_requests/review.html.erb
+++ b/app/views/absence_requests/review.html.erb
@@ -1,4 +1,4 @@
-<wrapper>
+<wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="lg-12 sm-12">
       <heading level="h1" size="h2">

--- a/app/views/absence_requests/show.html.erb
+++ b/app/views/absence_requests/show.html.erb
@@ -1,4 +1,4 @@
-<wrapper>
+<wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="lg-12 sm-12">
       <heading level="h1" size="h2">

--- a/app/views/absence_requests/show.html.erb
+++ b/app/views/absence_requests/show.html.erb
@@ -7,6 +7,10 @@
       <heading level="h2" size="h3">
         From <%= @absence_request.start_date %> to <%= @absence_request.end_date %>
       </heading>
+
+      <tag type="tag" :tag-items="[
+        {name: '<%= @absence_request.latest_status %>', color: '<%= @absence_request.status_color %>', icon: '<%= @absence_request.status_icon %>'}
+        ]"></tag>
     </grid-item>
   </grid-container>
   <grid-container>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,15 +3,15 @@
   <head>
     <title>Leave and Travel Requests</title>
     <%= javascript_pack_tag 'application' %>
-    <%= stylesheet_link_tag    'application', media: 'all' %>
     <%= stylesheet_pack_tag 'application' %>
+    <%= stylesheet_link_tag    'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
   </head>
 
   <body>
-    <library-header app-name="Leave and Travel Requests" app-url="<%= HomeURL.for(current_user: current_user) %>" class="lux">
+    <library-header app-name="Leave and Travel Requests" app-url="<%= HomeURL.for(current_user: current_user) %>" class="lux" :max-width=1440>
     <menu-bar type="links" :menu-items="[
         {name: 'My Requests', component: 'My Requests', href: '/my_requests/'},
       ]"/>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
     <%= javascript_include_tag 'application' %>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
 
   <body>

--- a/app/views/requests/my_requests.html.erb
+++ b/app/views/requests/my_requests.html.erb
@@ -55,12 +55,16 @@
   ]"></tag>
 </wrapper>
 
-<wrapper :max-width=1440>
-  <% @requests.each do |request| %>
-    <%= if request.request_type == 'TravelRequest'
-          render 'travel_requests/index_detail', travel_request: request
-        else
-          render 'absence_requests/index_detail', absence_request: request
-        end %>
-  <% end %>
+<wrapper :max-width=1440 class="my-request">
+<grid-container>
+    <grid-item columns="lg-12 sm-12">
+      <% @requests.each do |request| %>
+        <%= if request.request_type == 'TravelRequest'
+              render 'travel_requests/index_detail', travel_request: request
+            else
+              render 'absence_requests/index_detail', absence_request: request
+            end %>
+      <% end %>
+    </grid-item>
+  </grid-container>
 </wrapper>

--- a/app/views/requests/my_requests.html.erb
+++ b/app/views/requests/my_requests.html.erb
@@ -1,4 +1,4 @@
-<wrapper>
+<wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="lg-5 sm-12">
       <heading level="h1" size="h2">My Requests</heading>
@@ -9,7 +9,7 @@
     </grid-item>
   </grid-container>
 </wrapper>
-<wrapper>
+<wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="lg-5 sm-12">
     <%= form_tag(my_requests_path, method: :get) do %>
@@ -47,7 +47,7 @@
   </grid-container>
 </wrapper>
 
-<wrapper>
+<wrapper :max-width=1440>
   <tag type="filter" :tag-items="[
     <% @requests.filter_removal_urls.each do |key, url| %>
     {name: '<%= key %>', href: '<%= url %>'},
@@ -55,7 +55,7 @@
   ]"></tag>
 </wrapper>
 
-<wrapper>
+<wrapper :max-width=1440>
   <% @requests.each do |request| %>
     <%= if request.request_type == 'TravelRequest'
           render 'travel_requests/index_detail', travel_request: request

--- a/app/views/travel_requests/_index_detail.html.erb
+++ b/app/views/travel_requests/_index_detail.html.erb
@@ -7,7 +7,7 @@
       ><<%= travel_request.travel_category_icon %> /></lux-icon-base>
     </card-media>
     <card-header>
-      <heading level="h2" size="h3"><hyperlink href="<%= travel_request_path(travel_request.to_model)%>"></hyperlink><%= travel_request.event_title %></heading>
+      <heading level="h2" size="h3"><hyperlink href="<%= travel_request_path(travel_request.to_model)%>"><%= travel_request.event_title %></hyperlink></heading>
       <text-style><%= travel_request.formatted_start_date %> to <%= travel_request.formatted_end_date %></text-style>
     </card-header>
     <card-content>

--- a/app/views/travel_requests/_index_detail.html.erb
+++ b/app/views/travel_requests/_index_detail.html.erb
@@ -3,6 +3,7 @@
       <lux-icon-base
         width="50"
         height="50"
+        icon-color="rgb(65, 70, 78)"
       ><<%= travel_request.travel_category_icon %> /></lux-icon-base>
     </card-media>
     <card-header>
@@ -11,12 +12,10 @@
     </card-header>
     <card-content>
       <tag type="tag" :tag-items="[
-        {name: '<%= travel_request.latest_status %>', color: '<%= travel_request.status_color %>', icon: '<%= travel_request.status_icon %>'}
+        {name: '<%= travel_request.latest_status %>', color: '<%= travel_request.status_color %>'}
         ]"
-        horizontal="end"></tag>
-      <text-style type="span" variation="small"><lux-icon-base
-        width="14"
-        height="14"
-      ><<%= travel_request.status_icon %>/></lux-icon-base><%= travel_request.latest_status_date %></text-style>
+        horizontal="end"
+        size="small"></tag>
+      <text-style type="span" variation="small"><%= travel_request.latest_status_date %></text-style>
     </card-content>
   </card>

--- a/app/views/travel_requests/_index_detail.html.erb
+++ b/app/views/travel_requests/_index_detail.html.erb
@@ -10,9 +10,13 @@
       <text-style><%= travel_request.formatted_start_date %> to <%= travel_request.formatted_end_date %></text-style>
     </card-header>
     <card-content>
+      <tag type="tag" :tag-items="[
+        {name: '<%= travel_request.latest_status %>', color: '<%= travel_request.status_color %>', icon: '<%= travel_request.status_icon %>'}
+        ]"
+        horizontal="end"></tag>
       <text-style type="span" variation="small"><lux-icon-base
         width="14"
         height="14"
-      ><<%= travel_request.status_icon %>/></lux-icon-base><%= travel_request.latest_status %></text-style>
+      ><<%= travel_request.status_icon %>/></lux-icon-base><%= travel_request.latest_status_date %></text-style>
     </card-content>
   </card>

--- a/app/views/travel_requests/edit.html.erb
+++ b/app/views/travel_requests/edit.html.erb
@@ -1,4 +1,4 @@
-<wrapper>
+<wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="lg-12 sm-12">
       <heading level="h1" size="h2">Editing Travel Request</heading>

--- a/app/views/travel_requests/new.html.erb
+++ b/app/views/travel_requests/new.html.erb
@@ -1,5 +1,4 @@
-
-<wrapper>
+<wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="lg-12 sm-12">
       <heading level="h1" size="h2">New Travel Request</heading>

--- a/app/views/travel_requests/show.html.erb
+++ b/app/views/travel_requests/show.html.erb
@@ -8,15 +8,15 @@
       <heading level="h2" size="h3">
         From <%= @travel_request.start_date %> to <%= @travel_request.end_date %> in <%= @travel_request.event_requests[0].location %>
       </heading>
+
+      <tag type="tag" :tag-items="[
+        {name: '<%= @travel_request.latest_status %>', color: '<%= @travel_request.status_color %>', icon: '<%= @travel_request.status_icon %>'}
+        ]"></tag>
     </grid-item>
     <grid-item columns="lg-2 sm-6 auto">
       <card size="small" id="trip-id">
         <heading level="h2"><%= @travel_request.id %></heading>
         <text-style variation="default">Trip ID</text-style>
-        <tag type="tag" :tag-items="[
-        {name: '<%= @travel_request.latest_status %>', color: '<%= @travel_request.status_color %>', icon: '<%= @travel_request.status_icon %>'}
-        ]"
-        horizontal="center"></tag>
       </card>
     </grid-item>
   </grid-container>

--- a/app/views/travel_requests/show.html.erb
+++ b/app/views/travel_requests/show.html.erb
@@ -1,5 +1,5 @@
 <p id="notice"><%= notice %></p>
-<wrapper>
+<wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="lg-10 sm-6">
       <heading level="h1" size="h2">
@@ -13,6 +13,10 @@
       <card size="small" id="trip-id">
         <heading level="h2"><%= @travel_request.id %></heading>
         <text-style variation="default">Trip ID</text-style>
+        <tag type="tag" :tag-items="[
+        {name: '<%= @travel_request.latest_status %>', color: '<%= @travel_request.status_color %>', icon: '<%= @travel_request.status_icon %>'}
+        ]"
+        horizontal="center"></tag>
       </card>
     </grid-item>
   </grid-container>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/webpacker": "^4.0.2",
-    "lux-design-system": "^2.7.0",
+    "lux-design-system": "^2.8.0",
     "vue": "^2.6.10",
     "vue-loader": "^15.7.0",
     "vue-template-compiler": "^2.6.10"

--- a/spec/decorators/absence_request_decorator_spec.rb
+++ b/spec/decorators/absence_request_decorator_spec.rb
@@ -136,41 +136,41 @@ RSpec.describe AbsenceRequestDecorator, type: :model do
   describe "#status_icon" do
     let(:absence_request) { FactoryBot.create(:absence_request) }
     it "returns the correct lux icon" do
-      expect(absence_request_decorator.status_icon).to eq "lux-icon-clock"
+      expect(absence_request_decorator.status_icon).to eq "clock"
     end
 
     context "when absence has been apporved" do
       let(:absence_request) { FactoryBot.create(:absence_request, action: :approve) }
       it "returns the correct lux icon" do
-        expect(absence_request_decorator.status_icon).to eq "lux-icon-approved"
+        expect(absence_request_decorator.status_icon).to eq "approved"
       end
     end
 
     context "when absence has been denied" do
       let(:absence_request) { FactoryBot.create(:absence_request, action: :deny) }
       it "returns the correct lux icon" do
-        expect(absence_request_decorator.status_icon).to eq "lux-icon-denied"
+        expect(absence_request_decorator.status_icon).to eq "denied"
       end
     end
 
     context "when absence has been canceled" do
       let(:absence_request) { FactoryBot.create(:absence_request, action: :cancel) }
       it "returns the correct lux icon" do
-        expect(absence_request_decorator.status_icon).to eq "lux-icon-alert"
+        expect(absence_request_decorator.status_icon).to eq "alert"
       end
     end
 
     context "when absence has been recorded" do
       let(:absence_request) { FactoryBot.create(:absence_request, action: :record) }
       it "returns the correct lux icon" do
-        expect(absence_request_decorator.status_icon).to eq "lux-icon-reported"
+        expect(absence_request_decorator.status_icon).to eq "reported"
       end
     end
 
     context "when absence is pending cancelation" do
       let(:absence_request) { FactoryBot.create(:absence_request, action: :pending_cancel) }
       it "returns the correct lux icon" do
-        expect(absence_request_decorator.status_icon).to eq "lux-icon-remove"
+        expect(absence_request_decorator.status_icon).to eq "remove"
       end
     end
   end
@@ -183,7 +183,8 @@ RSpec.describe AbsenceRequestDecorator, type: :model do
     it "returns the last created status and date" do
       absence_request.approve!(agent: supervisor)
       absence_request.cancel!(agent: absence_request.creator)
-      expect(absence_request_decorator.latest_status).to eq "Canceled on #{today.strftime('%b %-d, %Y')}"
+      expect(absence_request_decorator.latest_status).to eq "Canceled"
+      expect(absence_request_decorator.latest_status_date).to eq "Updated on #{today.strftime('%b %-d, %Y')}"
     end
   end
 

--- a/spec/decorators/travel_request_decorator_spec.rb
+++ b/spec/decorators/travel_request_decorator_spec.rb
@@ -64,34 +64,34 @@ RSpec.describe TravelRequestDecorator, type: :model do
   describe "#status_icon" do
     let(:travel_request) { FactoryBot.create(:travel_request) }
     it "returns the correct lux icon" do
-      expect(travel_request_decorator.status_icon).to eq "lux-icon-clock"
+      expect(travel_request_decorator.status_icon).to eq "clock"
     end
 
     context "when travel has been approved" do
       let(:travel_request) { FactoryBot.create(:travel_request, action: :approve) }
       it "returns the correct lux icon" do
-        expect(travel_request_decorator.status_icon).to eq "lux-icon-approved"
+        expect(travel_request_decorator.status_icon).to eq "approved"
       end
     end
 
     context "when travel has been denied" do
       let(:travel_request) { FactoryBot.create(:travel_request, action: :deny) }
       it "returns the correct lux icon" do
-        expect(travel_request_decorator.status_icon).to eq "lux-icon-denied"
+        expect(travel_request_decorator.status_icon).to eq "denied"
       end
     end
 
     context "when travel has been changes_requested" do
       let(:travel_request) { FactoryBot.create(:travel_request, action: :change_request) }
       it "returns the correct lux icon" do
-        expect(travel_request_decorator.status_icon).to eq "lux-icon-refresh"
+        expect(travel_request_decorator.status_icon).to eq "refresh"
       end
     end
 
     context "when travel has been canceled" do
       let(:travel_request) { FactoryBot.create(:travel_request, action: :cancel) }
       it "returns the correct lux icon" do
-        expect(travel_request_decorator.status_icon).to eq "lux-icon-alert"
+        expect(travel_request_decorator.status_icon).to eq "alert"
       end
     end
   end
@@ -100,14 +100,16 @@ RSpec.describe TravelRequestDecorator, type: :model do
     let(:travel_request) { FactoryBot.create(:travel_request) }
     let(:today) { Time.zone.now }
     it "returns the status and the createddate" do
-      expect(travel_request_decorator.latest_status).to eq "Pending on #{today.strftime('%b %-d, %Y')}"
+      expect(travel_request_decorator.latest_status).to eq "Pending"
+      expect(travel_request_decorator.latest_status_date).to eq "Updated on #{today.strftime('%b %-d, %Y')}"
     end
 
     context "it has been approved and then canceled" do
       let(:travel_request) { FactoryBot.create(:travel_request, action: :approve) }
       it "returns the last created status and date" do
         travel_request.cancel!(agent: travel_request.creator)
-        expect(travel_request_decorator.latest_status).to eq "Canceled on #{today.strftime('%b %-d, %Y')}"
+        expect(travel_request_decorator.latest_status).to eq "Canceled"
+        expect(travel_request_decorator.latest_status_date).to eq "Updated on #{today.strftime('%b %-d, %Y')}"
       end
     end
 
@@ -116,7 +118,8 @@ RSpec.describe TravelRequestDecorator, type: :model do
       let(:travel_request) { FactoryBot.create(:travel_request, creator: creator) }
       it "returns pending futher approval" do
         travel_request.approve!(agent: travel_request.creator.supervisor)
-        expect(travel_request_decorator.latest_status).to eq "Pending further approval on #{today.strftime('%b %-d, %Y')}"
+        expect(travel_request_decorator.latest_status).to eq "Pending further approval"
+        expect(travel_request_decorator.latest_status_date).to eq "Updated on #{today.strftime('%b %-d, %Y')}"
       end
     end
   end

--- a/yarn.lock
+++ b/yarn.lock
@@ -6011,10 +6011,10 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-lux-design-system@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-2.7.0.tgz#06bf025eca5ca4d55bd5e5e7052ca76ec6ef4995"
-  integrity sha512-YHl6l/9F/4NQ6Wze38tQuJKtQXvGMkoNL3ln2vdeIY+4TsqivS48KlRM/rHT1W4DtZem0H3C6Af+JomrQYA8Iw==
+lux-design-system@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-2.8.0.tgz#452c19e7cc598ea4a631b20ea4bd683c0592b5d4"
+  integrity sha512-Oj3jvn3fagRf/MC5VXO2fRbbvV8CDdQAiArMlWmDWFtos8xFQ/hZw3QpkKLdpRwAdFpM16HAhHPIl9OY6gq4RQ==
   dependencies:
     lodash "^4.17.11"
     mini-css-extract-plugin "^0.4.5"


### PR DESCRIPTION
Closes #273 for the My Request page. The status tag has been added to the absence and travel show pages, but UI needs to be refactored. 

Need to update LUX version once https://github.com/pulibrary/lux/pull/251 is merged and a new release is published.

Closes #291