### PR TITLE
Adding state checks and state actions for TravelRequestController

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,4 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
     - 'lib/tasks/approvals.rake'
+    - 'config/routes.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,7 +10,3 @@
 # Configuration parameters: Max.
 RSpec/ExampleLength:
   Enabled: false
-Metrics/ClassLength:
-  Exclude:
-    - 'app/controllers/absence_requests_controller.rb'
-    - 'app/controllers/travel_requests_controller.rb'

--- a/app/change_sets/travel_request_change_set.rb
+++ b/app/change_sets/travel_request_change_set.rb
@@ -14,6 +14,8 @@ class TravelRequestChangeSet < Reform::Form
   validates :travel_category, inclusion: { in: Request.travel_categories.keys, allow_blank: true }
   validates :creator_id, presence: true
   validates :event_requests, presence: true
+  validates :purpose, presence: true
+  validates :participation, inclusion: { in: Request.participations.keys }
 
   def estimate_cost_options
     # turn key, value into label, key

--- a/app/controllers/absence_requests_controller.rb
+++ b/app/controllers/absence_requests_controller.rb
@@ -5,47 +5,47 @@ class AbsenceRequestsController < ApplicationController
   # GET /absence_requests/1
   # GET /absence_requests/1.json
   def show
-    @absence_request = AbsenceRequestDecorator.new(@absence_request)
+    @request = AbsenceRequestDecorator.new(@request)
   end
 
   # GET /absence_requests/new
   def new
-    @absence_request_change_set = absence_request_change_set
+    @request_change_set = request_change_set
   end
 
   # GET /absence_requests/1/edit
   def edit
-    @absence_request_change_set = absence_request_change_set
+    @request_change_set = request_change_set
 
     # render the default
-    return if @absence_request_change_set.model.pending?
+    return if @request_change_set.model.pending?
 
     # handle the error
     respond_to do |format|
-      @absence_request = absence_request_change_set.model
-      format.html { redirect_to @absence_request, notice: "Absence can not be edited after it has been #{@absence_request_change_set.model.status}." }
-      format.json { render :show, status: :invalid_edit, location: @absence_request }
+      @request = request_change_set.model
+      format.html { redirect_to @request, notice: "Absence can not be edited after it has been #{@request.status}." }
+      format.json { render :show, status: :invalid_edit, location: @request }
     end
   end
 
   # GET /absence_requests/1/review
   def review
-    @absence_request_change_set = absence_request_change_set
-    allowed_to_review = @absence_request_change_set.model.only_supervisor(agent: current_staff_profile)
+    @request_change_set = request_change_set
+    allowed_to_review = @request_change_set.model.only_supervisor(agent: current_staff_profile)
 
     # render the default
-    return if @absence_request_change_set.model.pending? && allowed_to_review
+    return if @request_change_set.model.pending? && allowed_to_review
 
     # handle the error
     respond_to do |format|
-      @absence_request = absence_request_change_set.model
+      @request = request_change_set.model
       message = if !allowed_to_review
                   "You are not allowed access to review this absence"
                 else
-                  "Absence can not be reviewed after it has been #{@absence_request_change_set.model.status}."
+                  "Absence can not be reviewed after it has been #{@request_change_set.model.status}."
                 end
-      format.html { redirect_to @absence_request, notice: message }
-      format.json { render :show, status: :invalid_edit, location: @absence_request }
+      format.html { redirect_to @request, notice: message }
+      format.json { render :show, status: :invalid_edit, location: @request }
     end
   end
 
@@ -53,14 +53,14 @@ class AbsenceRequestsController < ApplicationController
   # POST /absence_requests.json
   def create
     respond_to do |format|
-      if absence_request_change_set.validate(processed_params) && absence_request_change_set.save
-        @absence_request = absence_request_change_set.model
-        format.html { redirect_to @absence_request, notice: "Absence request was successfully created." }
-        format.json { render :show, status: :created, location: @absence_request }
+      if request_change_set.validate(processed_params) && request_change_set.save
+        @request = request_change_set.model
+        format.html { redirect_to @request, notice: "Absence request was successfully created." }
+        format.json { render :show, status: :created, location: @request }
       else
         copy_model_errors_to_change_set
         format.html { render :new }
-        format.json { render json: absence_request_change_set.errors, status: :unprocessable_entity }
+        format.json { render json: request_change_set.errors, status: :unprocessable_entity }
       end
     end
   end
@@ -69,14 +69,14 @@ class AbsenceRequestsController < ApplicationController
   # PATCH/PUT /absence_requests/1.json
   def update
     respond_to do |format|
-      if absence_request_change_set.validate(processed_params) && absence_request_change_set.save
-        @absence_request = absence_request_change_set.model
-        format.html { redirect_to @absence_request, notice: "Absence request was successfully updated." }
-        format.json { render :show, status: :ok, location: @absence_request }
+      if request_change_set.validate(processed_params) && request_change_set.save
+        @request = request_change_set.model
+        format.html { redirect_to @request, notice: "Absence request was successfully updated." }
+        format.json { render :show, status: :ok, location: @request }
       else
         copy_model_errors_to_change_set
         format.html { render :edit }
-        format.json { render json: absence_request_change_set.errors, status: :unprocessable_entity }
+        format.json { render json: request_change_set.errors, status: :unprocessable_entity }
       end
     end
   end
@@ -96,7 +96,7 @@ class AbsenceRequestsController < ApplicationController
   # DELETE /absence_requests/1
   # DELETE /absence_requests/1.json
   def destroy
-    @absence_request.destroy
+    @request.destroy
     respond_to do |format|
       format.html { redirect_to absence_requests_url, notice: "Absence request was successfully destroyed." }
       format.json { head :no_content }
@@ -107,11 +107,11 @@ class AbsenceRequestsController < ApplicationController
 
     # Use callbacks to share common setup or constraints between actions.
     def set_absence_request
-      @absence_request = AbsenceRequest.find(params[:id])
+      @request = AbsenceRequest.find(params[:id])
     end
 
-    def absence_request_change_set
-      @absence_request_change_set ||=
+    def request_change_set
+      @request_change_set ||=
         if params[:id]
           AbsenceRequestChangeSet.new(AbsenceRequest.find(params[:id]))
         else
@@ -120,8 +120,8 @@ class AbsenceRequestsController < ApplicationController
     end
 
     def copy_model_errors_to_change_set
-      absence_request_change_set.model.errors.each do |key, value|
-        @absence_request_change_set.errors.add(key, value)
+      request_change_set.model.errors.each do |key, value|
+        @request_change_set.errors.add(key, value)
       end
     end
 
@@ -147,28 +147,28 @@ class AbsenceRequestsController < ApplicationController
       allowed_to_change = can_change?(action: action)
       return unless allowed_to_change
 
-      absence_request_change_set.model.aasm.fire(action, agent: current_staff_profile) if allowed_to_change
+      request_change_set.model.aasm.fire(action, agent: current_staff_profile) if allowed_to_change
       respond_to do |format|
-        if allowed_to_change && absence_request_change_set.validate(processed_params) && absence_request_change_set.save
-          @absence_request = absence_request_change_set.model
-          format.html { redirect_to @absence_request, notice: "Absence request was successfully #{@absence_request.status}." }
-          format.json { render :show, status: :ok, location: @absence_request }
+        if allowed_to_change && request_change_set.validate(processed_params) && request_change_set.save
+          @request = request_change_set.model
+          format.html { redirect_to @request, notice: "Absence request was successfully #{@request.status}." }
+          format.json { render :show, status: :ok, location: @request }
         else
           copy_model_errors_to_change_set
           format.html { render :review }
-          format.json { render json: absence_request_change_set.errors, status: :unprocessable_entity }
+          format.json { render json: request_change_set.errors, status: :unprocessable_entity }
         end
       end
     end
 
     def can_change?(action:)
-      allowed_to_change = absence_request_change_set.model.only_supervisor(agent: current_staff_profile)
+      allowed_to_change = request_change_set.model.only_supervisor(agent: current_staff_profile)
       return allowed_to_change if allowed_to_change
 
       respond_to do |format|
-        @absence_request = absence_request_change_set.model
-        format.html { redirect_to @absence_request, notice: "You are not allowed access to #{action} this absence" }
-        format.json { render :show, status: :invalid_review, location: @absence_request }
+        @request = request_change_set.model
+        format.html { redirect_to @request, notice: "You are not allowed access to #{action} this absence" }
+        format.json { render :show, status: :invalid_review, location: @request }
       end
       allowed_to_change
     end

--- a/app/controllers/absence_requests_controller.rb
+++ b/app/controllers/absence_requests_controller.rb
@@ -1,109 +1,20 @@
 # frozen_string_literal: true
-class AbsenceRequestsController < ApplicationController
+class AbsenceRequestsController < CommonRequestController
   before_action :set_absence_request, only: [:show, :destroy]
 
-  # GET /absence_requests/1
-  # GET /absence_requests/1.json
-  def show
-    @request = AbsenceRequestDecorator.new(@request)
-  end
-
-  # GET /absence_requests/new
-  def new
-    @request_change_set = request_change_set
-  end
-
-  # GET /absence_requests/1/edit
-  def edit
-    @request_change_set = request_change_set
-
-    # render the default
-    return if @request_change_set.model.pending?
-
-    # handle the error
-    respond_to do |format|
-      @request = request_change_set.model
-      format.html { redirect_to @request, notice: "Absence can not be edited after it has been #{@request.status}." }
-      format.json { render :show, status: :invalid_edit, location: @request }
-    end
-  end
-
-  # GET /absence_requests/1/review
-  def review
-    @request_change_set = request_change_set
-    allowed_to_review = @request_change_set.model.only_supervisor(agent: current_staff_profile)
-
-    # render the default
-    return if @request_change_set.model.pending? && allowed_to_review
-
-    # handle the error
-    respond_to do |format|
-      @request = request_change_set.model
-      message = if !allowed_to_review
-                  "You are not allowed access to review this absence"
-                else
-                  "Absence can not be reviewed after it has been #{@request_change_set.model.status}."
-                end
-      format.html { redirect_to @request, notice: message }
-      format.json { render :show, status: :invalid_edit, location: @request }
-    end
-  end
-
-  # POST /absence_requests
-  # POST /absence_requests.json
-  def create
-    respond_to do |format|
-      if request_change_set.validate(processed_params) && request_change_set.save
-        @request = request_change_set.model
-        format.html { redirect_to @request, notice: "Absence request was successfully created." }
-        format.json { render :show, status: :created, location: @request }
-      else
-        copy_model_errors_to_change_set
-        format.html { render :new }
-        format.json { render json: request_change_set.errors, status: :unprocessable_entity }
-      end
-    end
-  end
-
-  # PATCH/PUT /absence_requests/1
-  # PATCH/PUT /absence_requests/1.json
-  def update
-    respond_to do |format|
-      if request_change_set.validate(processed_params) && request_change_set.save
-        @request = request_change_set.model
-        format.html { redirect_to @request, notice: "Absence request was successfully updated." }
-        format.json { render :show, status: :ok, location: @request }
-      else
-        copy_model_errors_to_change_set
-        format.html { render :edit }
-        format.json { render json: request_change_set.errors, status: :unprocessable_entity }
-      end
-    end
-  end
-
-  # PATCH/PUT /absence_requests/1/approve
-  # PATCH/PUT /absence_requests/1/approve.json
-  def approve
-    supervisor_action(action: :approve)
-  end
-
-  # PATCH/PUT /absence_requests/1/deny
-  # PATCH/PUT /absence_requests/1/deny.json
-  def deny
-    supervisor_action(action: :deny)
-  end
-
-  # DELETE /absence_requests/1
-  # DELETE /absence_requests/1.json
-  def destroy
-    @request.destroy
-    respond_to do |format|
-      format.html { redirect_to absence_requests_url, notice: "Absence request was successfully destroyed." }
-      format.json { head :no_content }
-    end
-  end
-
   private
+
+    def request_decorator_class
+      AbsenceRequestDecorator
+    end
+
+    def can_edit?
+      @request_change_set.model.pending?
+    end
+
+    def list_url
+      absence_requests_url
+    end
 
     # Use callbacks to share common setup or constraints between actions.
     def set_absence_request
@@ -117,12 +28,6 @@ class AbsenceRequestsController < ApplicationController
         else
           AbsenceRequestChangeSet.new(AbsenceRequest.new)
         end
-    end
-
-    def copy_model_errors_to_change_set
-      request_change_set.model.errors.each do |key, value|
-        @request_change_set.errors.add(key, value)
-      end
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.
@@ -141,35 +46,5 @@ class AbsenceRequestsController < ApplicationController
       Array(notes).map do |note_entry|
         note_entry.merge(creator_id: current_staff_profile.id) if note_entry[:content].present?
       end.compact
-    end
-
-    def supervisor_action(action:)
-      allowed_to_change = can_change?(action: action)
-      return unless allowed_to_change
-
-      request_change_set.model.aasm.fire(action, agent: current_staff_profile) if allowed_to_change
-      respond_to do |format|
-        if allowed_to_change && request_change_set.validate(processed_params) && request_change_set.save
-          @request = request_change_set.model
-          format.html { redirect_to @request, notice: "Absence request was successfully #{@request.status}." }
-          format.json { render :show, status: :ok, location: @request }
-        else
-          copy_model_errors_to_change_set
-          format.html { render :review }
-          format.json { render json: request_change_set.errors, status: :unprocessable_entity }
-        end
-      end
-    end
-
-    def can_change?(action:)
-      allowed_to_change = request_change_set.model.only_supervisor(agent: current_staff_profile)
-      return allowed_to_change if allowed_to_change
-
-      respond_to do |format|
-        @request = request_change_set.model
-        format.html { redirect_to @request, notice: "You are not allowed access to #{action} this absence" }
-        format.json { render :show, status: :invalid_review, location: @request }
-      end
-      allowed_to_change
     end
 end

--- a/app/controllers/common_request_controller.rb
+++ b/app/controllers/common_request_controller.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+class CommonRequestController < ApplicationController
+  # GET
+  def show
+    @request = request_decorator_class.new(@request)
+  end
+
+  # GET
+  def new
+    # the sync is required since the form currently runs off of the change set model
+    # prepopulate creates a default unsaved request event
+    request_change_set.prepopulate!.sync
+  end
+
+  # GET
+  def edit
+    @request_change_set = request_change_set
+
+    # render the default
+    return if can_edit?
+
+    # handle the error
+    respond_with_show_error(message: "#{model_instance_to_name(@request_change_set.model)} can not be edited after it has been #{@request_change_set.model.status}.",
+                            status: :invalid_edit)
+  end
+
+  # POST
+  def create
+    update_model_and_respond(handle_deletes: false, success_verb: "created", error_action: :new)
+  end
+
+  # PATCH/PUT
+  def update
+    update_model_and_respond(handle_deletes: true, success_verb: "updated", error_action: :edit)
+  end
+
+  # DELETE
+  def destroy
+    @request.destroy
+    respond_to do |format|
+      format.html { redirect_to list_url, notice: "#{model_instance_to_name(@request)} was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  # GET
+  def review
+    @request_change_set = request_change_set
+    allowed_to_review = @request_change_set.model.only_supervisor(agent: current_staff_profile)
+
+    # render the default
+    return if @request_change_set.model.pending? && allowed_to_review
+
+    message = if allowed_to_review
+                "#{model_instance_to_name(@request)} can not be reviewed after it has been #{@request_change_set.model.status}."
+              else
+                "You are not allowed access to review this #{model_instance_to_name(@request)}"
+              end
+
+    # handle the error
+    respond_with_show_error(message: message, status: :invalid_edit)
+  end
+
+  # PATCH/PUT
+  # PATCH/PUT
+  def approve
+    supervisor_action(action: :approve)
+  end
+
+  # PATCH/PUT
+  def deny
+    supervisor_action(action: :deny)
+  end
+
+  private
+
+    def respond_with_show_error(message:, status:)
+      respond_to do |format|
+        @request = request_change_set.model
+        format.html { redirect_to @request, notice: message }
+        format.json { render :show, status: status, location: @request }
+      end
+    end
+
+    def handle_nested_deletes
+      true
+    end
+
+    def model_instance_to_name(model)
+      model.class.name.underscore.humanize
+    end
+
+    def copy_model_errors_to_change_set
+      request_change_set.model.errors.each do |key, value|
+        @request_change_set.errors.add(key, value)
+      end
+    end
+
+    def update_model_and_respond(handle_deletes:, success_verb:, error_action:)
+      valid = request_change_set.validate(processed_params)
+      handle_nested_deletes if valid && handle_deletes
+      valid &&= request_change_set.save
+
+      respond_to do |format|
+        if valid
+          @request = request_change_set.model
+          format.html { redirect_to @request, notice: "#{model_instance_to_name(@request)} was successfully #{success_verb}." }
+          format.json { render :show, status: :ok, location: @request }
+        else
+          copy_model_errors_to_change_set
+          format.html { render error_action }
+          format.json { render json: request_change_set.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+
+    def supervisor_action(action:)
+      allowed_to_change = can_change?(action: action)
+      return unless allowed_to_change
+
+      request = request_change_set.model
+      request.aasm.fire(action, agent: current_staff_profile) if allowed_to_change
+
+      update_model_and_respond(handle_deletes: false, success_verb: request.status, error_action: :review)
+    end
+
+    def can_change?(action:)
+      allowed_to_change = request_change_set.model.only_supervisor(agent: current_staff_profile)
+      return allowed_to_change if allowed_to_change
+
+      respond_to do |format|
+        @request = request_change_set.model
+        format.html { redirect_to @request, notice: "You are not allowed access to #{action} this absence" }
+        format.json { render :show, status: :invalid_review, location: @request }
+      end
+      allowed_to_change
+    end
+end

--- a/app/controllers/travel_requests_controller.rb
+++ b/app/controllers/travel_requests_controller.rb
@@ -5,37 +5,37 @@ class TravelRequestsController < ApplicationController
   # GET /travel_requests/1
   # GET /travel_requests/1.json
   def show
-    @travel_request = TravelRequestDecorator.new(@travel_request)
+    @request = TravelRequestDecorator.new(@request)
   end
 
   # GET /travel_requests/new
   def new
     # the sync is required since the form currently runs off of the change set model
     # prepopulate creates a default unsaved request event
-    travel_request_change_set.prepopulate!.sync
+    request_change_set.prepopulate!.sync
   end
 
   # GET /travel_requests/1/edit
   def edit
-    @travel_request_change_set = travel_request_change_set
+    @request_change_set = request_change_set
   end
 
   # POST /travel_requests
   # POST /travel_requests.json
   def create
-    @travel_request_change_set = travel_request_change_set
+    @request_change_set = request_change_set
 
     respond_to do |format|
-      if travel_request_change_set.validate(processed_params) && travel_request_change_set.save
-        @travel_request = travel_request_change_set.model
-        format.html { redirect_to @travel_request, notice: "Travel request was successfully created." }
-        format.json { render :show, status: :created, location: @travel_request }
+      if request_change_set.validate(processed_params) && request_change_set.save
+        @request = request_change_set.model
+        format.html { redirect_to @request, notice: "Travel request was successfully created." }
+        format.json { render :show, status: :created, location: @request }
       else
         # the sync is required since the form currently runs off of the change set model
-        travel_request_change_set.sync
+        request_change_set.sync
         copy_model_errors_to_change_set
         format.html { render :new }
-        format.json { render json: travel_request_change_set.errors, status: :unprocessable_entity }
+        format.json { render json: request_change_set.errors, status: :unprocessable_entity }
       end
     end
   end
@@ -44,14 +44,14 @@ class TravelRequestsController < ApplicationController
   # PATCH/PUT /travel_requests/1.json
   def update
     respond_to do |format|
-      if travel_request_change_set.validate(processed_params) && remove_estimates && travel_request_change_set.save
-        @travel_request = travel_request_change_set.model
-        format.html { redirect_to @travel_request, notice: "Travel request was successfully updated." }
-        format.json { render :show, status: :ok, location: @travel_request }
+      if request_change_set.validate(processed_params) && remove_estimates && request_change_set.save
+        @request = request_change_set.model
+        format.html { redirect_to @request, notice: "Travel request was successfully updated." }
+        format.json { render :show, status: :ok, location: @request }
       else
         copy_model_errors_to_change_set
         format.html { render :edit }
-        format.json { render json: travel_request_change_set.errors, status: :unprocessable_entity }
+        format.json { render json: request_change_set.errors, status: :unprocessable_entity }
       end
     end
   end
@@ -59,7 +59,7 @@ class TravelRequestsController < ApplicationController
   # DELETE /travel_requests/1
   # DELETE /travel_requests/1.json
   def destroy
-    @travel_request.destroy
+    @request.destroy
     respond_to do |format|
       format.html { redirect_to travel_requests_url, notice: "Travel request was successfully destroyed." }
       format.json { head :no_content }
@@ -70,11 +70,11 @@ class TravelRequestsController < ApplicationController
 
     # Use callbacks to share common setup or constraints between actions.
     def set_travel_request
-      @travel_request = TravelRequest.find(params[:id])
+      @request = TravelRequest.find(params[:id])
     end
 
-    def travel_request_change_set
-      @travel_request_change_set ||=
+    def request_change_set
+      @request_change_set ||=
         if params[:id]
           TravelRequestChangeSet.new(TravelRequest.find(params[:id]))
         else
@@ -83,8 +83,8 @@ class TravelRequestsController < ApplicationController
     end
 
     def copy_model_errors_to_change_set
-      travel_request_change_set.model.errors.each do |key, value|
-        @travel_request_change_set.errors.add(key, value)
+      request_change_set.model.errors.each do |key, value|
+        @request_change_set.errors.add(key, value)
       end
     end
 
@@ -107,7 +107,7 @@ class TravelRequestsController < ApplicationController
     def remove_estimates
       return true if params[:travel_request][:estimates].blank?
       params_estimate_ids = params[:travel_request][:estimates].map { |estimate| estimate[:id] }
-      @travel_request.estimates.each do |estimate|
+      @request.estimates.each do |estimate|
         estimate.destroy if params_estimate_ids.exclude? estimate.id.to_s
       end
       true

--- a/app/decorators/absence_request_decorator.rb
+++ b/app/decorators/absence_request_decorator.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 class AbsenceRequestDecorator < RequestDecorator
-  delegate :absence_type, :hours_requested, to: :absence_request
+  delegate :absence_type, :hours_requested, to: :request
   attr_reader :absence_request
 
   def initialize(absence_request)
     super(absence_request)
-    @absence_request = absence_request
+    @request = absence_request
   end
 
   def absence_type_icon

--- a/app/decorators/travel_request_decorator.rb
+++ b/app/decorators/travel_request_decorator.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 class TravelRequestDecorator < RequestDecorator
   delegate :participation, :purpose, :travel_category, :event_title,
-           :event_requests, :estimates, :status, to: :travel_request
+           :event_requests, :estimates, :status, to: :request
   attr_reader :travel_request
 
   def initialize(travel_request)
     super(travel_request)
-    @travel_request = travel_request
+    @request = travel_request
   end
 
   def estimates_json

--- a/app/views/absence_requests/_form.html.erb
+++ b/app/views/absence_requests/_form.html.erb
@@ -1,12 +1,12 @@
-  <%= form_with(model: absence_request_change_set.model, local: true) do |form| %>
+  <%= form_with(model: request_change_set.model, local: true) do |form| %>
     <grid-container>
-    <% if absence_request_change_set.errors.any? %>
+    <% if request_change_set.errors.any? %>
       <grid-item columns="lg-12">
         <alert status="error">
-          <h2><%= pluralize(absence_request_change_set.errors.count, "error") %> prohibited this absence_request_change_set from being saved:</h2>
+          <h2><%= pluralize(request_change_set.errors.count, "error") %> prohibited this request_change_set from being saved:</h2>
 
           <ul>
-          <% absence_request_change_set.errors.full_messages.each do |message| %>
+          <% request_change_set.errors.full_messages.each do |message| %>
             <li><%= message %></li>
           <% end %>
           </ul>
@@ -17,8 +17,8 @@
 
     <grid-item columns="lg-12">
       <input-select label="Absence type" name="absence_request[absence_type]" id="absence_request_absence_type" 
-                    value="<%= absence_request_change_set.absence_type %>" 
-                    :options="<%= absence_request_change_set.absence_type_options %>"
+                    value="<%= request_change_set.absence_type %>" 
+                    :options="<%= request_change_set.absence_type_options %>"
                     required=true
       ></input-select>
     </grid-item>
@@ -27,11 +27,11 @@
       <date-picker id="absence_request_end_date" name="absence_request[end_date]" label="End Date" mode="single"></date-picker>
     </grid-item>-->
 
-    <hours-calculator start-date="<%= absence_request_change_set.start_date_js %>"
-                      end-date="<%= absence_request_change_set.end_date_js %>"
-                      hours-requested="<%= absence_request_change_set.hours_requested %>"
-                      :holidays="<%=absence_request_change_set.holidays %>" 
-                      hours-per-day=<%= absence_request_change_set.hours_per_day%>>
+    <hours-calculator start-date="<%= request_change_set.start_date_js %>"
+                      end-date="<%= request_change_set.end_date_js %>"
+                      hours-requested="<%= request_change_set.hours_requested %>"
+                      :holidays="<%=request_change_set.holidays %>" 
+                      hours-per-day=<%= request_change_set.hours_per_day%>>
     </hours-calculator>
 
     <grid-item columns="lg-6 sm-12">
@@ -40,7 +40,7 @@
     </grid-item>
 
     <grid-item columns="lg-12 sm-12">
-    <text-style variation="emphasis">This request will be submitted to: <%= absence_request_change_set.supervisor(current_staff_profile) %></text-style>
+    <text-style variation="emphasis">This request will be submitted to: <%= request_change_set.supervisor(current_staff_profile) %></text-style>
       <input-button type="submit" variation="solid">Apply Changes</input-button>
     </grid-item>
     </grid-container>

--- a/app/views/absence_requests/edit.html.erb
+++ b/app/views/absence_requests/edit.html.erb
@@ -5,6 +5,6 @@
     </grid-item>
   </grid-container>
   
-  <%= render 'form', absence_request_change_set: @absence_request_change_set %>
+  <%= render 'form', request_change_set: @request_change_set %>
 
 </wrapper>

--- a/app/views/absence_requests/new.html.erb
+++ b/app/views/absence_requests/new.html.erb
@@ -5,6 +5,6 @@
     </grid-item>
   </grid-container>
   
-<%= render 'form', absence_request_change_set: @absence_request_change_set %>
+<%= render 'form', request_change_set: @request_change_set %>
 
 </wrapper>

--- a/app/views/absence_requests/review.html.erb
+++ b/app/views/absence_requests/review.html.erb
@@ -2,10 +2,10 @@
   <grid-container>
     <grid-item columns="lg-12 sm-12">
       <heading level="h1" size="h2">
-        <%= @absence_request.requestor_status %>
+        <%= @request.requestor_status %>
       </heading>
       <heading level="h2" size="h3">
-        From <%= @absence_request.start_date %> to <%= @absence_request.end_date %>
+        From <%= @request.start_date %> to <%= @request.end_date %>
       </heading>
     </grid-item>
   </grid-container>
@@ -13,16 +13,16 @@
     <grid-item columns="lg-3 sm-12">
       <text-style>Total Hours Requested</text-style>
       <heading level="h3" size="h4">
-        <%= @absence_request.hours_requested%> Hours
+        <%= @request.hours_requested%> Hours
 
       </heading>
-      <%=  render partial: "shared/request_note", collection: @absence_request.notes_and_changes, as: :note %>
+      <%=  render partial: "shared/request_note", collection: @request.notes_and_changes, as: :note %>
     </grid-item>
     <grid-item columns="lg-9 sm-12" :offset="true">
       <text-style variation="strong">Team members absent during this time period</text-style>
-        <%=  render partial: "shared/absent_staff", collection: @absence_request.absent_staff, as: :staff %>
+        <%=  render partial: "shared/absent_staff", collection: @request.absent_staff, as: :staff %>
     </grid-item>
   </grid-container>
-  <hyperlink href="<%= edit_absence_request_path(@absence_request.request) %>" variation="button solid">Edit</hyperlink>
+  <hyperlink href="<%= edit_absence_request_path(@request.request) %>" variation="button solid">Edit</hyperlink>
   <hyperlink href="<%= my_requests_path %>" variation="button solid">Back</hyperlink>
 </wrapper>

--- a/app/views/absence_requests/show.html.erb
+++ b/app/views/absence_requests/show.html.erb
@@ -2,14 +2,14 @@
   <grid-container>
     <grid-item columns="lg-12 sm-12">
       <heading level="h1" size="h2">
-        <%= @absence_request.requestor_status %>
+        <%= @request.requestor_status %>
       </heading>
       <heading level="h2" size="h3">
-        From <%= @absence_request.start_date %> to <%= @absence_request.end_date %>
+        From <%= @request.start_date %> to <%= @request.end_date %>
       </heading>
 
       <tag type="tag" :tag-items="[
-        {name: '<%= @absence_request.latest_status %>', color: '<%= @absence_request.status_color %>', icon: '<%= @absence_request.status_icon %>'}
+        {name: '<%= @request.latest_status %>', color: '<%= @request.status_color %>', icon: '<%= @request.status_icon %>'}
         ]"></tag>
     </grid-item>
   </grid-container>
@@ -17,19 +17,19 @@
     <grid-item columns="lg-3 sm-12">
       <text-style>Total Hours Requested</text-style>
       <heading level="h3" size="h4">
-        <%= @absence_request.hours_requested%> Hours
+        <%= @request.hours_requested%> Hours
 
       </heading>
-      <%=  render partial: "shared/request_note", collection: @absence_request.notes_and_changes, as: :note %>
+      <%=  render partial: "shared/request_note", collection: @request.notes_and_changes, as: :note %>
     </grid-item>
     <grid-item columns="lg-9 sm-12" :offset="true">
       <text-style variation="strong">Team members absent during this time period</text-style>
-        <%=  render partial: "shared/absent_staff", collection: @absence_request.absent_staff, as: :staff %>
+        <%=  render partial: "shared/absent_staff", collection: @request.absent_staff, as: :staff %>
     </grid-item>
   </grid-container>
   <grid-container>
     <grid-item>
-      <hyperlink href="<%= edit_absence_request_path(@absence_request.request) %>" variation="button solid">Edit</hyperlink>
+      <hyperlink href="<%= edit_absence_request_path(@request.request) %>" variation="button solid">Edit</hyperlink>
       <hyperlink href="<%= my_requests_path %>" variation="button solid">Back</hyperlink>
     </grid-item>
   </gird-container>

--- a/app/views/absence_requests/show.json.jbuilder
+++ b/app/views/absence_requests/show.json.jbuilder
@@ -1,2 +1,2 @@
 # frozen_string_literal: true
-json.partial! "absence_requests/absence_request", absence_request: @absence_request
+json.partial! "absence_requests/absence_request", absence_request: @request

--- a/app/views/travel_requests/_form.html.erb
+++ b/app/views/travel_requests/_form.html.erb
@@ -1,11 +1,11 @@
 
-<%= form_with(model: travel_request_change_set.model, local: true) do |form| %>
-<% if travel_request_change_set.errors.any? %>
+<%= form_with(model: request_change_set.model, local: true) do |form| %>
+<% if request_change_set.errors.any? %>
   <div id="error_explanation">
-    <h2><%= pluralize(travel_request_change_set.errors.count, "error") %> prohibited this travel_request from being saved:</h2>
+    <h2><%= pluralize(request_change_set.errors.count, "error") %> prohibited this travel_request from being saved:</h2>
 
     <ul>
-    <% travel_request_change_set.errors.full_messages.each do |message| %>
+    <% request_change_set.errors.full_messages.each do |message| %>
       <li><%= message %></li>
     <% end %>
     </ul>
@@ -21,8 +21,8 @@
             id="travel_request_event_requests_attributes_0_recurring_event_id"
             name="travel_request[event_requests_attributes][0][recurring_event_id]"
             label="Recurring Event"
-            value="<%= travel_request_change_set.event_id %>"
-            :list="<%= travel_request_change_set.recurring_event_list %>">
+            value="<%= request_change_set.event_id %>"
+            :list="<%= request_change_set.recurring_event_list %>">
           </input-data-list>
         <date-picker label="Event Dates" mode="range" width="expand" required=true
           id="travel_request_event_requests_attributes_0_event_dates"
@@ -32,18 +32,18 @@
               start: null,
             end: new Date(<%= Date.current.year %>, <%= Date.current.month - 1 %>, <%= Date.current.day %>)
             }]"
-          :default-dates="<%=travel_request_change_set.event_dates_js%>"
+          :default-dates="<%=request_change_set.event_dates_js%>"
         ></date-picker>
         <input-text label="Location" type="text" name="travel_request[event_requests_attributes][0][location]" required=true
-              id="travel_request_event_requests_attributes_0_location" width="expand" value="<%= travel_request_change_set.model.event_requests[0].location %>">
+              id="travel_request_event_requests_attributes_0_location" width="expand" value="<%= request_change_set.model.event_requests[0].location %>">
         </input-text>
     <% end %>
   </grid-item>
   <grid-item columns="lg-3 sm-6">
       <input-select label="Participation" name="travel_request[participation]"
           id="travel_request_participation" width="expand"
-          value="<%= travel_request_change_set.participation %>"
-          :options="<%= travel_request_change_set.participation_options %>" required=true></input-select>
+          value="<%= request_change_set.participation %>"
+          :options="<%= request_change_set.participation_options %>" required=true></input-select>
       <date-picker label="Travel Dates" mode="range" width="expand"
         name="travel_request[travel_dates]" id="travel_request_travel_dates"
         :disabled-dates="
@@ -51,14 +51,14 @@
             start: null,
           end: new Date(<%= Date.current.year %>, <%= Date.current.month - 1 %>, <%= Date.current.day %>)
           }]"
-        :default-dates="<%=travel_request_change_set.travel_dates_js%>"
+        :default-dates="<%=request_change_set.travel_dates_js%>"
 
       >
       </date-picker>
       <input-text label="Purpose" id="travel_request_purpose" width="expand" required=true
-        name="travel_request[purpose]" value="<%= travel_request_change_set.purpose %>"
+        name="travel_request[purpose]" value="<%= request_change_set.purpose %>"
         helper="Specify the reason this trip is necissary for your job"
-        :options="<%= travel_request_change_set.travel_category_options %>"></input-text>
+        :options="<%= request_change_set.travel_category_options %>"></input-text>
   </grid-item>
   <grid-item columns="lg-6 sm-12">
     <input-text id="notes" name="notes"
@@ -72,8 +72,8 @@
   <!--
     Travel Estimate Form -->
   <travel-estimate-form
-    :expenses="<%= travel_request_change_set.estimates_json %>"
-    :cost_types="<%= travel_request_change_set.estimate_cost_options %>">
+    :expenses="<%= request_change_set.estimates_json %>"
+    :cost_types="<%= request_change_set.estimate_cost_options %>">
   </travel-estimate-form>
 
 <grid-container>

--- a/app/views/travel_requests/edit.html.erb
+++ b/app/views/travel_requests/edit.html.erb
@@ -4,6 +4,6 @@
       <heading level="h1" size="h2">Editing Travel Request</heading>
     </grid-item>
   </grid-container>
-  <%= render 'form', travel_request_change_set: @travel_request_change_set %>
-  <hyperlink href="<%=  travel_request_path(@travel_request_change_set.model.id) %>" variation="button solid">Show</hyperlink>
+  <%= render 'form', request_change_set: @request_change_set %>
+  <hyperlink href="<%=  travel_request_path(@request_change_set.model.id) %>" variation="button solid">Show</hyperlink>
 </wrapper>

--- a/app/views/travel_requests/new.html.erb
+++ b/app/views/travel_requests/new.html.erb
@@ -4,6 +4,6 @@
       <heading level="h1" size="h2">New Travel Request</heading>
     </grid-item>
   </grid-container>
-  <%= render 'form', travel_request_change_set: @travel_request_change_set %>
+  <%= render 'form', request_change_set: @request_change_set %>
   <hyperlink href="<%= my_requests_path %>" variation="button solid">Back</hyperlink>
 </wrapper>

--- a/app/views/travel_requests/review.html.erb
+++ b/app/views/travel_requests/review.html.erb
@@ -1,0 +1,28 @@
+<wrapper :max-width=1440>
+  <grid-container>
+    <grid-item columns="lg-12 sm-12">
+      <heading level="h1" size="h2">
+        <%= @request.requestor_status %>
+      </heading>
+      <heading level="h2" size="h3">
+        From <%= @request.start_date %> to <%= @request.end_date %>
+      </heading>
+    </grid-item>
+  </grid-container>
+  <grid-container>
+    <grid-item columns="lg-3 sm-12">
+      <text-style>Total Hours Requested</text-style>
+      <heading level="h3" size="h4">
+        <%= @request.hours_requested%> Hours
+
+      </heading>
+      <%=  render partial: "shared/request_note", collection: @request.notes_and_changes, as: :note %>
+    </grid-item>
+    <grid-item columns="lg-9 sm-12" :offset="true">
+      <text-style variation="strong">Team members absent during this time period</text-style>
+        <%=  render partial: "shared/absent_staff", collection: @request.absent_staff, as: :staff %>
+    </grid-item>
+  </grid-container>
+  <hyperlink href="<%= edit_absence_request_path(@request.request) %>" variation="button solid">Edit</hyperlink>
+  <hyperlink href="<%= my_requests_path %>" variation="button solid">Back</hyperlink>
+</wrapper>

--- a/app/views/travel_requests/show.html.erb
+++ b/app/views/travel_requests/show.html.erb
@@ -2,19 +2,19 @@
   <grid-container>
     <grid-item columns="lg-10 sm-6">
       <heading level="h1" size="h2">
-        <%= @travel_request.requestor_status %>
+        <%= @request.requestor_status %>
       </heading>
       <heading level="h2" size="h3">
-        From <%= @travel_request.start_date %> to <%= @travel_request.end_date %> in <%= @travel_request.event_requests[0].location %>
+        From <%= @request.start_date %> to <%= @request.end_date %> in <%= @request.event_requests[0].location %>
       </heading>
 
       <tag type="tag" :tag-items="[
-        {name: '<%= @travel_request.latest_status %>', color: '<%= @travel_request.status_color %>', icon: '<%= @travel_request.status_icon %>'}
+        {name: '<%= @request.latest_status %>', color: '<%= @request.status_color %>', icon: '<%= @request.status_icon %>'}
         ]"></tag>
     </grid-item>
     <grid-item columns="lg-2 sm-6 auto">
       <card size="small" id="trip-id">
-        <heading level="h2"><%= @travel_request.id %></heading>
+        <heading level="h2"><%= @request.id %></heading>
         <text-style variation="default">Trip ID</text-style>
       </card>
     </grid-item>
@@ -24,37 +24,37 @@
       <heading level="h3" size="h4">
         Level of Participation
       </heading>
-      <text-style variation="default"><%= @travel_request.participation.blank? ? 'Unknown' : @travel_request.participation %></text-style>
+      <text-style variation="default"><%= @request.participation.blank? ? 'Unknown' : @request.participation %></text-style>
       <heading level="h3" size="h4">
         Purpose
       </heading>
-      <text-style variation="default"><%= @travel_request.purpose.blank? ? 'Unknown' : @travel_request.purpose %></text-style>
+      <text-style variation="default"><%= @request.purpose.blank? ? 'Unknown' : @request.purpose %></text-style>
     </grid-item>
     <grid-item columns="lg-5 sm-12">
       <heading level="h3" size="h4">
         Others who requested to go
       </heading>
-      <%=  render partial: "other_staff", collection: @travel_request.event_attendees, as: :staff %>
+      <%=  render partial: "other_staff", collection: @request.event_attendees, as: :staff %>
     </grid-item>
     <grid-item columns="lg-4 sm-12">
       <heading level="h3" size="h4">
         Team members absent during this time period
       </heading>
-      <%=  render partial: "shared/absent_staff", collection: @travel_request.absent_staff, as: :staff %>
+      <%=  render partial: "shared/absent_staff", collection: @request.absent_staff, as: :staff %>
     </grid-item>
   </grid-container>
   <grid-container>
     <grid-item columns="lg-3 sm-12">
-      <%=  render partial: "shared/request_note", collection: @travel_request.notes_and_changes, as: :note %>
+      <%=  render partial: "shared/request_note", collection: @request.notes_and_changes, as: :note %>
     </grid-item>
     <grid-item columns="lg-9 sm-12" :offset="true">
       <data-table caption="Anticipated Expenses"
-        :columns="<%= @travel_request.estimate_fields_json %>"
-        :json-data="<%= @travel_request.estimates_json %>">
+        :columns="<%= @request.estimate_fields_json %>"
+        :json-data="<%= @request.estimates_json %>">
       </data-table>
     </grid-item>
   </grid-container>
 
-  <hyperlink href="<%= edit_travel_request_path(@travel_request.id) %>" variation="button solid">Edit</hyperlink>
+  <hyperlink href="<%= edit_travel_request_path(@request.id) %>" variation="button solid">Edit</hyperlink>
   <hyperlink href="<%= my_requests_path %>" variation="button solid">Back</hyperlink>
 </wrapper>

--- a/app/views/travel_requests/show.json.jbuilder
+++ b/app/views/travel_requests/show.json.jbuilder
@@ -1,2 +1,2 @@
 # frozen_string_literal: true
-json.partial! "travel_requests/travel_request", travel_request: @travel_request
+json.partial! "travel_requests/travel_request", travel_request: @request

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,16 @@ Rails.application.routes.draw do
   end
 
   resources :recurring_events
-  resources :travel_requests, except: [:index]
+
+  resources :travel_requests, except: [:index] do
+    member do
+      get "review"
+      put "approve"
+      put "deny"
+      put "change_request"
+    end
+  end
+
   resources :absence_requests, except: [:index] do
     member do
       get "review"

--- a/spec/change_sets/travel_request_change_set_spec.rb
+++ b/spec/change_sets/travel_request_change_set_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe TravelRequestChangeSet, type: :model do
   let(:recurring_event) { FactoryBot.create :recurring_event }
   let(:travel_request_errors) do
     {
-      creator_id: ["can't be blank"]
+      creator_id: ["can't be blank"],
+      participation: ["is not included in the list"],
+      purpose: ["can't be blank"]
     }
   end
 
@@ -24,7 +26,7 @@ RSpec.describe TravelRequestChangeSet, type: :model do
     context "with valid params" do
       let(:valid_params) do
         {
-          travel_category: "business", creator_id: 1,
+          travel_category: "business", creator_id: 1, purpose: "my grand purpose", participation: "presenter",
           event_requests: [recurring_event_id: recurring_event.id, start_date: Time.zone.now, location: "Kalamazoo"]
         }
       end

--- a/spec/controllers/absence_requests_controller_spec.rb
+++ b/spec/controllers/absence_requests_controller_spec.rb
@@ -231,9 +231,9 @@ RSpec.describe AbsenceRequestsController, type: :controller do
         post :create, params: { absence_request: invalid_attributes }, session: valid_session
         expect(response).to be_successful
         expect(assigns(:request_change_set).errors.messages).to eq(absence_type: ["is not included in the list"],
-                                                                           end_date: ["can't be blank"],
-                                                                           hours_requested: ["can't be blank"],
-                                                                           start_date: ["can't be blank"])
+                                                                   end_date: ["can't be blank"],
+                                                                   hours_requested: ["can't be blank"],
+                                                                   start_date: ["can't be blank"])
       end
 
       it "returns json with errors" do

--- a/spec/controllers/absence_requests_controller_spec.rb
+++ b/spec/controllers/absence_requests_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe AbsenceRequestsController, type: :controller do
       absence_request = FactoryBot.create(:absence_request)
       get :show, params: { id: absence_request.to_param }, session: valid_session
       expect(response).to be_successful
-      assert_equal absence_request, assigns(:absence_request).request
+      assert_equal absence_request, assigns(:request).request
     end
   end
 
@@ -68,7 +68,7 @@ RSpec.describe AbsenceRequestsController, type: :controller do
     it "returns a success response" do
       get :new, params: {}, session: valid_session
       expect(response).to be_successful
-      expect(assigns(:absence_request_change_set)).to be_a AbsenceRequestChangeSet
+      expect(assigns(:request_change_set)).to be_a AbsenceRequestChangeSet
     end
   end
 
@@ -77,42 +77,42 @@ RSpec.describe AbsenceRequestsController, type: :controller do
       absence_request = FactoryBot.create(:absence_request)
       get :edit, params: { id: absence_request.to_param }, session: valid_session
       expect(response).to be_successful
-      expect(assigns(:absence_request_change_set)).to be_a AbsenceRequestChangeSet
+      expect(assigns(:request_change_set)).to be_a AbsenceRequestChangeSet
     end
 
     it "can not edit an approved request" do
       absence_request = FactoryBot.create(:absence_request, action: "approve")
       get :edit, params: { id: absence_request.to_param }, session: valid_session
       expect(response).to redirect_to(absence_request)
-      expect(assigns(:absence_request)).to eq(absence_request)
+      expect(assigns(:request)).to eq(absence_request)
     end
 
     it "can not edit a denied request" do
       absence_request = FactoryBot.create(:absence_request, action: "deny")
       get :edit, params: { id: absence_request.to_param }, session: valid_session
       expect(response).to redirect_to(absence_request)
-      expect(assigns(:absence_request)).to eq(absence_request)
+      expect(assigns(:request)).to eq(absence_request)
     end
 
     it "can not edit a recorded request" do
       absence_request = FactoryBot.create(:absence_request, action: "record")
       get :edit, params: { id: absence_request.to_param }, session: valid_session
       expect(response).to redirect_to(absence_request)
-      expect(assigns(:absence_request)).to eq(absence_request)
+      expect(assigns(:request)).to eq(absence_request)
     end
 
     it "can not edit a canceled request" do
       absence_request = FactoryBot.create(:absence_request, action: "cancel")
       get :edit, params: { id: absence_request.to_param }, session: valid_session
       expect(response).to redirect_to(absence_request)
-      expect(assigns(:absence_request)).to eq(absence_request)
+      expect(assigns(:request)).to eq(absence_request)
     end
 
     it "can not edit a pending cancelation request" do
       absence_request = FactoryBot.create(:absence_request, action: "pending_cancel")
       get :edit, params: { id: absence_request.to_param }, session: valid_session
       expect(response).to redirect_to(absence_request)
-      expect(assigns(:absence_request)).to eq(absence_request)
+      expect(assigns(:request)).to eq(absence_request)
     end
   end
 
@@ -122,14 +122,14 @@ RSpec.describe AbsenceRequestsController, type: :controller do
       absence_request = FactoryBot.create(:absence_request, creator: staff_profile)
       get :review, params: { id: absence_request.to_param }, session: valid_session
       expect(response).to be_successful
-      expect(assigns(:absence_request_change_set)).to be_a AbsenceRequestChangeSet
+      expect(assigns(:request_change_set)).to be_a AbsenceRequestChangeSet
     end
 
     it "does not allow the creator to review" do
       absence_request = FactoryBot.create(:absence_request, creator: creator)
       get :review, params: { id: absence_request.to_param }, session: valid_session
       expect(response).to redirect_to(absence_request)
-      expect(assigns(:absence_request)).to eq(absence_request)
+      expect(assigns(:request)).to eq(absence_request)
     end
 
     it "Does not allow review after denied" do
@@ -137,7 +137,7 @@ RSpec.describe AbsenceRequestsController, type: :controller do
       absence_request = FactoryBot.create(:absence_request, creator: staff_profile, action: "deny")
       get :review, params: { id: absence_request.to_param }, session: valid_session
       expect(response).to redirect_to(absence_request)
-      expect(assigns(:absence_request)).to eq(absence_request)
+      expect(assigns(:request)).to eq(absence_request)
     end
   end
 
@@ -157,7 +157,7 @@ RSpec.describe AbsenceRequestsController, type: :controller do
       notes = { notes: [{ content: "Important message" }] }
       put :approve, params: { id: absence_request.to_param, absence_request: notes }, session: valid_session
       expect(response).to redirect_to(absence_request)
-      expect(assigns(:absence_request)).to eq(absence_request)
+      expect(assigns(:request)).to eq(absence_request)
     end
 
     context "with invalid params" do
@@ -166,7 +166,7 @@ RSpec.describe AbsenceRequestsController, type: :controller do
         absence_request = FactoryBot.create(:absence_request, creator: staff_profile)
         put :approve, params: { id: absence_request.to_param, absence_request: invalid_attributes }, session: valid_session
         expect(response).to be_successful
-        expect(assigns(:absence_request_change_set).errors.messages).to eq(absence_type: ["is not included in the list"])
+        expect(assigns(:request_change_set).errors.messages).to eq(absence_type: ["is not included in the list"])
       end
     end
   end
@@ -187,7 +187,7 @@ RSpec.describe AbsenceRequestsController, type: :controller do
       notes = { notes: [{ content: "Important message" }] }
       put :deny, params: { id: absence_request.to_param, absence_request: notes }, session: valid_session
       expect(response).to redirect_to(absence_request)
-      expect(assigns(:absence_request)).to eq(absence_request)
+      expect(assigns(:request)).to eq(absence_request)
     end
 
     context "with invalid params" do
@@ -196,7 +196,7 @@ RSpec.describe AbsenceRequestsController, type: :controller do
         absence_request = FactoryBot.create(:absence_request, creator: staff_profile)
         put :deny, params: { id: absence_request.to_param, absence_request: invalid_attributes }, session: valid_session
         expect(response).to be_successful
-        expect(assigns(:absence_request_change_set).errors.messages).to eq(absence_type: ["is not included in the list"])
+        expect(assigns(:request_change_set).errors.messages).to eq(absence_type: ["is not included in the list"])
       end
     end
   end
@@ -213,7 +213,7 @@ RSpec.describe AbsenceRequestsController, type: :controller do
         post :create, params: { absence_request: valid_attributes }, session: valid_session
         absence_request = AbsenceRequest.last
         expect(response).to redirect_to(absence_request)
-        expect(assigns(:absence_request)).to eq(absence_request)
+        expect(assigns(:request)).to eq(absence_request)
         expect(absence_request.creator_id).to eq creator.id
       end
 
@@ -221,7 +221,7 @@ RSpec.describe AbsenceRequestsController, type: :controller do
         post :create, params: { absence_request: valid_attributes, format: :json }, session: valid_session
         absence_request = AbsenceRequest.last
         expect(response.media_type).to eq("application/json")
-        expect(assigns(:absence_request)).to eq(absence_request)
+        expect(assigns(:request)).to eq(absence_request)
         expect(absence_request.creator_id).to eq creator.id
       end
     end
@@ -230,7 +230,7 @@ RSpec.describe AbsenceRequestsController, type: :controller do
       it "returns a success response (i.e. to display the 'new' template)" do
         post :create, params: { absence_request: invalid_attributes }, session: valid_session
         expect(response).to be_successful
-        expect(assigns(:absence_request_change_set).errors.messages).to eq(absence_type: ["is not included in the list"],
+        expect(assigns(:request_change_set).errors.messages).to eq(absence_type: ["is not included in the list"],
                                                                            end_date: ["can't be blank"],
                                                                            hours_requested: ["can't be blank"],
                                                                            start_date: ["can't be blank"])
@@ -256,7 +256,7 @@ RSpec.describe AbsenceRequestsController, type: :controller do
       it "returns a success response (i.e. to display the 'new' template)" do
         post :create, params: { absence_request: valid_attributes }, session: valid_session
         expect(response).to be_successful
-        expect(assigns(:absence_request_change_set).errors.messages).to eq(request: ["must exist"], creator: ["must exist"])
+        expect(assigns(:request_change_set).errors.messages).to eq(request: ["must exist"], creator: ["must exist"])
       end
 
       it "returns json with errors" do
@@ -304,7 +304,7 @@ RSpec.describe AbsenceRequestsController, type: :controller do
       it "redirects to the absence_request" do
         put :update, params: { id: absence_request.to_param, absence_request: nested_attributes }, session: valid_session
         expect(response).to redirect_to(absence_request)
-        expect(assigns(:absence_request).notes.first.attributes.with_indifferent_access).to include(nested_attributes[:notes].first)
+        expect(assigns(:request).notes.first.attributes.with_indifferent_access).to include(nested_attributes[:notes].first)
       end
     end
 
@@ -321,7 +321,7 @@ RSpec.describe AbsenceRequestsController, type: :controller do
       it "returns a success response (i.e. to display the 'new' template)" do
         put :update, params: { id: absence_request.to_param, absence_request: valid_attributes }, session: valid_session
         expect(response).to be_successful
-        expect(assigns(:absence_request_change_set).errors.messages).to eq(request: ["must exist"], creator: ["must exist"])
+        expect(assigns(:request_change_set).errors.messages).to eq(request: ["must exist"], creator: ["must exist"])
       end
 
       it "returns json with errors" do

--- a/spec/controllers/travel_requests_controller_spec.rb
+++ b/spec/controllers/travel_requests_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe TravelRequestsController, type: :controller do
       travel_request = FactoryBot.create(:travel_request)
       get :show, params: { id: travel_request.to_param }, session: valid_session
       expect(response).to be_successful
-      assert_equal travel_request, assigns(:travel_request).to_model
+      assert_equal travel_request, assigns(:request).to_model
     end
   end
 
@@ -78,9 +78,9 @@ RSpec.describe TravelRequestsController, type: :controller do
     it "returns a success response" do
       get :new, params: {}, session: valid_session
       expect(response).to be_successful
-      travel_request_change_set = assigns(:travel_request_change_set)
-      expect(travel_request_change_set).to be_a(TravelRequestChangeSet)
-      expect(travel_request_change_set.event_requests[0].model.start_date).to eq(Time.zone.today.to_date)
+      request_change_set = assigns(:request_change_set)
+      expect(request_change_set).to be_a(TravelRequestChangeSet)
+      expect(request_change_set.event_requests[0].model.start_date).to eq(Time.zone.today.to_date)
     end
   end
 
@@ -89,8 +89,8 @@ RSpec.describe TravelRequestsController, type: :controller do
       travel_request = FactoryBot.create(:travel_request)
       get :edit, params: { id: travel_request.to_param }, session: valid_session
       expect(response).to be_successful
-      expect(assigns(:travel_request_change_set)).to be_a(TravelRequestChangeSet)
-      assert_equal travel_request, assigns(:travel_request_change_set).model
+      expect(assigns(:request_change_set)).to be_a(TravelRequestChangeSet)
+      assert_equal travel_request, assigns(:request_change_set).model
     end
   end
 
@@ -112,7 +112,7 @@ RSpec.describe TravelRequestsController, type: :controller do
       it "redirects to the created travel_request" do
         post :create, params: { travel_request: valid_attributes }, session: valid_session
         expect(response).to redirect_to(TravelRequest.last)
-        assert_equal TravelRequest.last, assigns(:travel_request)
+        assert_equal TravelRequest.last, assigns(:request)
       end
     end
 
@@ -120,7 +120,7 @@ RSpec.describe TravelRequestsController, type: :controller do
       it "returns a success response (i.e. to display the 'new' template)" do
         post :create, params: { travel_request: invalid_attributes }, session: valid_session
         expect(response).to be_successful
-        expect(assigns(:travel_request_change_set)).to be_a(TravelRequestChangeSet)
+        expect(assigns(:request_change_set)).to be_a(TravelRequestChangeSet)
       end
     end
   end
@@ -152,7 +152,7 @@ RSpec.describe TravelRequestsController, type: :controller do
         travel_request = FactoryBot.create(:travel_request)
         put :update, params: { id: travel_request.to_param, travel_request: nested_attributes }, session: valid_session
         expect(response).to redirect_to(travel_request)
-        expect(assigns(:travel_request)).to be_a(TravelRequest)
+        expect(assigns(:request)).to be_a(TravelRequest)
       end
 
       # rubocop:disable RSpec/AnyInstance
@@ -169,7 +169,7 @@ RSpec.describe TravelRequestsController, type: :controller do
         it "returns a success response (i.e. to display the 'new' template)" do
           put :update, params: { id: travel_request.to_param, travel_request: valid_attributes }, session: valid_session
           expect(response).to be_successful
-          expect(assigns(:travel_request_change_set).errors.messages).to eq(request: ["must exist"], creator: ["must exist"])
+          expect(assigns(:request_change_set).errors.messages).to eq(request: ["must exist"], creator: ["must exist"])
         end
 
         it "returns json with errors" do
@@ -207,7 +207,7 @@ RSpec.describe TravelRequestsController, type: :controller do
       it "returns a success response (i.e. to display the 'edit' template)" do
         travel_request = FactoryBot.create(:travel_request)
         put :update, params: { id: travel_request.to_param, travel_request: invalid_nested_attributes }, session: valid_session
-        expect(assigns(:travel_request_change_set).event_requests.last.recurring_event_id).to eq recurring_event.id.to_s
+        expect(assigns(:request_change_set).event_requests.last.recurring_event_id).to eq recurring_event.id.to_s
       end
     end
   end

--- a/spec/factories/travel_requests.rb
+++ b/spec/factories/travel_requests.rb
@@ -6,6 +6,8 @@ FactoryBot.define do
     event_requests { [FactoryBot.build(:event_request)] }
     start_date { Time.zone.today }
     end_date { Time.zone.tomorrow }
+    purpose { "My grand purpose" }
+    participation { "other" }
     transient do
       action { nil }
     end

--- a/spec/views/absence_requests/edit.html.erb_spec.rb
+++ b/spec/views/absence_requests/edit.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "absence_requests/edit", type: :view do
     FactoryBot.create(:absence_request, absence_type: "vacation")
   end
   before do
-    assign(:absence_request_change_set, AbsenceRequestChangeSet.new(absence_request, start_date: Date.parse("2019-12-23"), end_date: Date.parse("2019-12-27")))
+    assign(:request_change_set, AbsenceRequestChangeSet.new(absence_request, start_date: Date.parse("2019-12-23"), end_date: Date.parse("2019-12-27")))
   end
 
   it "renders the edit absence_request form" do

--- a/spec/views/absence_requests/new.html.erb_spec.rb
+++ b/spec/views/absence_requests/new.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "absence_requests/new", type: :view do
     FactoryBot.build(:absence_request, absence_type: "vacation")
   end
   before do
-    assign(:absence_request_change_set, AbsenceRequestChangeSet.new(absence_request, start_date: Date.parse("2019-12-23"), end_date: Date.parse("2019-12-27")))
+    assign(:request_change_set, AbsenceRequestChangeSet.new(absence_request, start_date: Date.parse("2019-12-23"), end_date: Date.parse("2019-12-27")))
   end
 
   it "renders new absence_request form" do

--- a/spec/views/absence_requests/show.html.erb_spec.rb
+++ b/spec/views/absence_requests/show.html.erb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "absence_requests/show", type: :view do
   let(:creator) { FactoryBot.create(:staff_profile, :with_supervisor, given_name: "Sally", surname: "Smith") }
   let(:absence_request) { AbsenceRequestDecorator.new(FactoryBot.create(:absence_request, :with_note, creator: creator)) }
   before do
-    @absence_request = assign(:absence_request, absence_request)
+    @request = assign(:request, absence_request)
   end
 
   it "renders attributes in <p>" do

--- a/spec/views/travel_requests/edit.html.erb_spec.rb
+++ b/spec/views/travel_requests/edit.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "travel_requests/edit", type: :view do
                                        travel_category: "business")
   end
   before do
-    assign(:travel_request_change_set, TravelRequestChangeSet.new(travel_request))
+    assign(:request_change_set, TravelRequestChangeSet.new(travel_request))
   end
 
   it "renders the edit travel_request form" do

--- a/spec/views/travel_requests/new.html.erb_spec.rb
+++ b/spec/views/travel_requests/new.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "travel_requests/new", type: :view do
                                       travel_category: "business")
   end
   before do
-    assign(:travel_request_change_set, TravelRequestChangeSet.new(travel_request))
+    assign(:request_change_set, TravelRequestChangeSet.new(travel_request))
   end
 
   it "renders new travel_request form" do

--- a/spec/views/travel_requests/show.html.erb_spec.rb
+++ b/spec/views/travel_requests/show.html.erb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "travel_requests/show", type: :view do
   let(:creator) { FactoryBot.create(:staff_profile, :with_supervisor, given_name: "Sally", surname: "Smith") }
   let(:travel_request) { FactoryBot.create(:travel_request, :with_note_and_estimate, creator: creator) }
   before do
-    @travel_request = assign(:travel_request, TravelRequestDecorator.new(travel_request))
+    @request = assign(:request, TravelRequestDecorator.new(travel_request))
   end
 
   it "renders attributes in <p>" do


### PR DESCRIPTION
There is a large rename, which is the first commit, to make the request being handled by the view have a generic name.  This set up the refactoring of the AbsenceRequestController and the TravelRequestController into a CommonRequestController for the common actions between the two controllers.

This allowed the TravelRequestController to respond correctly to review, approve, and deny.
I addition I added the change_request action to the TravelRequestController.

Additional refactoring was then done on the common commands between actions, so that the rubocop todo could be removed.

While making these changes I also noticed that the TravelRequestChangeset was not validating the purpose and the participation, so I added that in also.