### PR TITLE
Adding event request generation when the Event is a string

### DIFF
--- a/app/change_sets/event_request_change_set.rb
+++ b/app/change_sets/event_request_change_set.rb
@@ -8,9 +8,22 @@ class EventRequestChangeSet < Reform::Form
   validates :recurring_event_id, :start_date, :location, presence: true
 
   validate :recurring_event_id do
-    if recurring_event_id.present?
+    begin
+      Integer recurring_event_id
       errors.add(:recurring_event_id, "must be a RecurringEvent") if recurring_event.blank?
+    rescue ArgumentError, TypeError
+      true # either string or nil so we do not expect it to be found
     end
+  end
+
+  def recurring_event_id=(value)
+    begin
+      Integer value
+    rescue ArgumentError
+      @recurring_event ||= ::RecurringEvent.create!(name: value)
+      value = @recurring_event.id
+    end
+    super value
   end
 
   def prepopulate!(options)

--- a/spec/change_sets/travel_request_change_set_spec.rb
+++ b/spec/change_sets/travel_request_change_set_spec.rb
@@ -36,6 +36,24 @@ RSpec.describe TravelRequestChangeSet, type: :model do
       end
     end
 
+    context "with a new Event" do
+      let(:valid_params) do
+        {
+          travel_category: "business", creator_id: 1, purpose: "my grand purpose", participation: "presenter",
+          event_requests: [recurring_event_id: "New Event", start_date: Time.zone.now, location: "Kalamazoo"]
+        }
+      end
+
+      it "is valid" do
+        expect do
+          expect(travel_request.validate(valid_params)).to be_truthy
+          expect(travel_request.validate(valid_params)).to be_truthy
+          expect(travel_request.validate(valid_params)).to be_truthy
+          expect(travel_request.validate(valid_params)).to be_truthy
+        end.to change(RecurringEvent, :count).by(1)
+      end
+    end
+
     context "with empty params" do
       let(:errors) { travel_request_errors.merge(event_requests: ["can't be blank"]) }
 

--- a/spec/controllers/travel_requests_controller_spec.rb
+++ b/spec/controllers/travel_requests_controller_spec.rb
@@ -186,6 +186,30 @@ RSpec.describe TravelRequestsController, type: :controller do
       end
     end
 
+    context "with fre text event" do
+      let(:valid_attributes) do
+        {
+          creator_id: creator.id,
+          start_date: start_date,
+          end_date: end_date,
+          request_type: "TravelRequest",
+          purpose: "Travel to campus for in-person meetings",
+          participation: "member",
+          event_requests: [
+            recurring_event_id: "A new event",
+            location: "Mumbai",
+            event_dates: "#{Time.zone.yesterday.strftime('%m/%d/%Y')} - #{Time.zone.today.strftime('%m/%d/%Y')}"
+          ],
+          travel_category: "business", # note this field is not available on the create form; only on approval.
+        }
+      end
+
+      it "redirects to the created travel_request" do
+        post :create, params: { travel_request: valid_attributes }, session: valid_session
+        expect(response).to redirect_to(TravelRequest.last)
+        assert_equal TravelRequest.last, assigns(:request)
+      end
+    end
     context "with invalid params" do
       it "returns a success response (i.e. to display the 'new' template)" do
         post :create, params: { travel_request: invalid_attributes }, session: valid_session


### PR DESCRIPTION
refs #318

This code works, but I have some reservations about it.  Should we be just creating a recurring event with what ever they send us?  Should we check for an event that is named the same first?  Should there be some other way to generate these events?  Should they have to fill in a description if they want to create an event?