### PR TITLE
Expands absence form inputs to match travel form

### DIFF
--- a/app/javascript/components/hoursCalculator.vue
+++ b/app/javascript/components/hoursCalculator.vue
@@ -4,6 +4,7 @@
       name="absence_request[start_date]"
       label="Date range"
       mode="range"
+      width="expand"
       placeholder="9/2/2019 - 9/12/2019"
       @updateInput="setHours($event)"
       :defaultDates="defaultDates">
@@ -13,7 +14,13 @@
     <input type="hidden" id="absence_request_start_date" name="absence_request[start_date]" :value="localStartDate">
     <input type="hidden" id="absence_request_end_date" name="absence_request[end_date]" :value="localEndDate">
 
-    <input-text id="absence_request_hours_requested" name="absence_request[hours_requested]" label="Total hours requested" placeholder="111 hours" :value="localHoursReqested" required></input-text>
+    <input-text id="absence_request_hours_requested" 
+                name="absence_request[hours_requested]" 
+                width="expand" 
+                label="Total hours requested" 
+                placeholder="111 hours" 
+                :value="localHoursReqested" 
+                required></input-text>
   </div>
 </template>
 

--- a/app/views/absence_requests/_form.html.erb
+++ b/app/views/absence_requests/_form.html.erb
@@ -15,8 +15,10 @@
     <% end %>
 
 
-    <grid-item columns="lg-4 sm-12">
-      <input-select label="Absence type" name="absence_request[absence_type]" id="absence_request_absence_type" 
+    <grid-item columns="lg-3 sm-12">
+      <input-select label="Absence type" name="absence_request[absence_type]" 
+                    id="absence_request_absence_type" 
+                    width="expand"
                     value="<%= request_change_set.absence_type %>" 
                     :options="<%= request_change_set.absence_type_options %>"
                     required=true


### PR DESCRIPTION
Adds `width="expand"` to inputs in absence form to resolve issues with cut off dates and maintain consistency with travel form.