### PR TITLE
Fixes Travel request expense issues 378, 374, and 373

### DIFF
--- a/app/change_sets/travel_request_change_set.rb
+++ b/app/change_sets/travel_request_change_set.rb
@@ -62,7 +62,8 @@ class TravelRequestChangeSet < Reform::Form
         cost_type: estimate.cost_type,
         amount: estimate.amount,
         recurrence: estimate.recurrence,
-        description: estimate.description
+        description: estimate.description,
+        other_id: SecureRandom.uuid
       }
     end.to_json
   end

--- a/app/javascript/components/travelEstimateForm.vue
+++ b/app/javascript/components/travelEstimateForm.vue
@@ -82,7 +82,7 @@ export default {
       this.expenseData.push({ id: null, cost_type: null, recurrence: 1, amount: 0, description: '', other_id: 'id_'+this.expenseData.length })
     },
     deleteExpense(expense) {
-      let foundIndex = this.expenseData.findIndex(x => x.id == expense.other_id)
+      let foundIndex = this.expenseData.findIndex(x => x.other_id == expense.other_id)
       this.expenseData.splice(foundIndex, 1)
     },
     setLineItemTotal(expense) {

--- a/app/javascript/components/travelEstimateForm.vue
+++ b/app/javascript/components/travelEstimateForm.vue
@@ -70,7 +70,7 @@ export default {
   props: {
     expenses: {
      type: Array,
-     default: () => [{ id: 'id_0', cost_type: null, recurrence: 1, amount: 0, description: '', other_id: 'id_0' }]
+     default: () => [{ id: null, cost_type: null, recurrence: 1, amount: 0, description: '', other_id: 'id_0' }]
     },
     cost_types: {
      type: Array,
@@ -79,10 +79,10 @@ export default {
   },
   methods: {
     addExpense() {
-      this.expenseData.push({ id: 'id_'+this.expenseData.length, cost_type: null, recurrence: 1, amount: 0, description: '', other_id: 'id_'+this.expenseData.length })
+      this.expenseData.push({ id: null, cost_type: null, recurrence: 1, amount: 0, description: '', other_id: 'id_'+this.expenseData.length })
     },
     deleteExpense(expense) {
-      let foundIndex = this.expenseData.findIndex(x => x.id == expense.id)
+      let foundIndex = this.expenseData.findIndex(x => x.id == expense.other_id)
       this.expenseData.splice(foundIndex, 1)
     },
     setLineItemTotal(expense) {

--- a/app/javascript/components/travelEstimateForm.vue
+++ b/app/javascript/components/travelEstimateForm.vue
@@ -1,12 +1,5 @@
 <template>
   <grid-container>
-    <grid-item columns="lg-12 sm-12 auto" :offset="true">
-      <input-button type="button" id="add-expense-button" variation="text"
-        @button-clicked="addExpense()">
-        <lux-icon-base width="12" height="12" icon-name="Add Expense">
-          <lux-icon-add></lux-icon-add>
-        </lux-icon-base> Add Expense</input-button>
-    </grid-item>
     <grid-item columns="lg-12 sm-12" v-for="expense in expenseData" v-bind:key="expense.id">
       <grid-container>
         <grid-item :vertical="center" columns="lg-1 sm-12">
@@ -50,7 +43,14 @@
     <grid-item columns="lg-12 sm-12">
       <hr/>
     </grid-item>
-    <grid-item columns="lg-10 sm-12 auto" :offset="true">
+    <grid-item columns="lg-2 sm-12 auto">
+      <input-button type="button" id="add-expense-button" variation="text"
+        @button-clicked="addExpense()">
+        <lux-icon-base width="12" height="12" icon-name="Add Expense">
+          <lux-icon-add></lux-icon-add>
+        </lux-icon-base> Add Expense</input-button>
+    </grid-item>
+    <grid-item columns="lg-8 sm-12 auto" :offset="true">
       <text-style variation="strong">Total:</text-style>
     </grid-item>
     <grid-item columns="lg-2 sm-12">
@@ -63,6 +63,7 @@
 export default {
   name: "travelEstimateForm",
   data: function () {
+    console.log(this.expenses)
     return {
       expenseData: this.expenses,
     }
@@ -70,7 +71,7 @@ export default {
   props: {
     expenses: {
      type: Array,
-     default: [{ id: null, cost_type: null, recurrence: 1, amount: 0, description: '' }]
+     default: () => [{ id: 'id_0', cost_type: null, recurrence: 1, amount: 0, description: '', other_id: 'id_0' }]
     },
     cost_types: {
      type: Array,
@@ -79,9 +80,11 @@ export default {
   },
   methods: {
     addExpense() {
-      this.expenseData.push({ id: null, cost_type: null, recurrence: 1, amount: 0, description: '', other_id: 'id_'+this.expenseData.length })
+      this.expenseData.push({ id: 'id_'+this.expenseData.length, cost_type: null, recurrence: 1, amount: 0, description: '', other_id: 'id_'+this.expenseData.length })
     },
     deleteExpense(expense) {
+      console.log(expense)
+      console.log(this.expenseData)
       let foundIndex = this.expenseData.findIndex(x => x.id == expense.id)
       this.expenseData.splice(foundIndex, 1)
     },

--- a/app/javascript/components/travelEstimateForm.vue
+++ b/app/javascript/components/travelEstimateForm.vue
@@ -63,7 +63,6 @@
 export default {
   name: "travelEstimateForm",
   data: function () {
-    console.log(this.expenses)
     return {
       expenseData: this.expenses,
     }
@@ -83,8 +82,6 @@ export default {
       this.expenseData.push({ id: 'id_'+this.expenseData.length, cost_type: null, recurrence: 1, amount: 0, description: '', other_id: 'id_'+this.expenseData.length })
     },
     deleteExpense(expense) {
-      console.log(expense)
-      console.log(this.expenseData)
       let foundIndex = this.expenseData.findIndex(x => x.id == expense.id)
       this.expenseData.splice(foundIndex, 1)
     },

--- a/app/javascript/test/travelEstimateForm.spec.js
+++ b/app/javascript/test/travelEstimateForm.spec.js
@@ -56,7 +56,6 @@ describe("travelEstimateForm.vue", () => {
   })
 
   it("deletes the appropriate expense line", () => {
-    // let id = wrapper.vm.expenseData[0].other_id
     wrapper.vm.deleteExpense(wrapper.vm.expenseData[0])
     expect(wrapper.vm.expenseData.length).toBe(1)
     let emptyArray = wrapper.vm.expenseData.filter(expense => {

--- a/app/javascript/test/travelEstimateForm.spec.js
+++ b/app/javascript/test/travelEstimateForm.spec.js
@@ -10,8 +10,8 @@ describe("travelEstimateForm.vue", () => {
       localVue,
       propsData: {
         expenses: [
-          {"id":1,"cost_type":"registration","amount":"50.0","recurrence":2,"description":""},
-          {"id":2,"cost_type":"meals","amount":"193.0","recurrence":1,"description":"Foo!"}
+          {"id":1,"cost_type":"registration","amount":"50.0","recurrence":2,"description":"","other_id":"id_1"},
+          {"id":2,"cost_type":"meals","amount":"193.0","recurrence":1,"description":"Foo!","other_id":"id_2"}
         ],
         cost_types: [
           {label: 'Ground transportation', value: 'ground_transportation'},
@@ -56,11 +56,11 @@ describe("travelEstimateForm.vue", () => {
   })
 
   it("deletes the appropriate expense line", () => {
-    let id = wrapper.vm.expenseData[0].id
+    // let id = wrapper.vm.expenseData[0].other_id
     wrapper.vm.deleteExpense(wrapper.vm.expenseData[0])
     expect(wrapper.vm.expenseData.length).toBe(1)
     let emptyArray = wrapper.vm.expenseData.filter(expense => {
-      return expense.id === 1
+      return expense.other_id === "id_1"
     })
     expect(emptyArray.length).toBe(0)
   })

--- a/app/views/travel_requests/_form.html.erb
+++ b/app/views/travel_requests/_form.html.erb
@@ -71,8 +71,11 @@
 </grid-container>
   <!--
     Travel Estimate Form -->
+
   <travel-estimate-form
-    :expenses="<%= request_change_set.estimates_json_form %>"
+    <% unless request_change_set.estimates_json_form == '[]' %>
+      :expenses="<%= request_change_set.estimates_json_form %>"
+    <% end %>
     :cost_types="<%= request_change_set.estimate_cost_options %>">
   </travel-estimate-form>
 

--- a/spec/features/new_travel_request_spec.rb
+++ b/spec/features/new_travel_request_spec.rb
@@ -28,8 +28,6 @@ RSpec.feature "New Leave Request", type: :feature, js: true do
     fill_in "travel_request_event_requests_attributes_0_location", with: "A Place To Be"
     fill_in "travel_request_purpose", with: "A grand purpose"
 
-    click_on "add-expense-button"
-
     find("#travel_request_estimates_cost_type option[value='air']").select_option
     fill_in "travel_request_estimates_recurrence", with: "2"
     fill_in "travel_request_estimates_amount", with: "20"


### PR DESCRIPTION
@carolyncole this bug was related to the use of the "other_id" for expenses. We are using estimate.id as a key to delete rows, but new rows ids are set to null and they use other_ids. We need to be able to delete both new and saved rows, so I am generating an "other_id" for existing (aka, saved) expenses as well.  

This PR fixes #378, #374 , and #373 

Just needs some tests now...