### PR TITLE
re-labels and alphabetizes cost input-select options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ coverage
 
 .yalc/
 yalc.lock
+.DS_Store

--- a/app/change_sets/travel_request_change_set.rb
+++ b/app/change_sets/travel_request_change_set.rb
@@ -33,7 +33,7 @@ class TravelRequestChangeSet < Reform::Form
 
   def estimate_cost_options
     # turn key, value into label, key
-    cost_types = Estimate.cost_types.sort_by {|key, value| value}
+    cost_types = Estimate.cost_types.sort_by { |_key, value| value }
     strings = cost_types.map do |key, value|
       "{label: '#{value.humanize}', value: '#{key}'}"
     end

--- a/app/change_sets/travel_request_change_set.rb
+++ b/app/change_sets/travel_request_change_set.rb
@@ -33,7 +33,8 @@ class TravelRequestChangeSet < Reform::Form
 
   def estimate_cost_options
     # turn key, value into label, key
-    strings = Estimate.cost_types.map do |key, value|
+    cost_types = Estimate.cost_types.sort_by {|key, value| value}
+    strings = cost_types.map do |key, value|
       "{label: '#{value.humanize}', value: '#{key}'}"
     end
     "[#{strings.join(',')}]"

--- a/app/javascript/test/travelEstimateForm.spec.js
+++ b/app/javascript/test/travelEstimateForm.spec.js
@@ -14,14 +14,14 @@ describe("travelEstimateForm.vue", () => {
           {"id":2,"cost_type":"meals","amount":"193.0","recurrence":1,"description":"Foo!","other_id":"id_2"}
         ],
         cost_types: [
-          {label: 'Ground transportation', value: 'ground_transportation'},
-          {label: 'Lodging', value: 'lodging'},{label: 'Meals', value: 'meals'},
-          {label: 'Misc', value: 'misc'},{label: 'Registration', value: 'registration'},
-          {label: 'Rental vehicle', value: 'rental_vehicle'},
-          {label: 'Air', value: 'air'},{label: 'Taxi', value: 'taxi'},
-          {label: 'Personal auto', value: 'personal_auto'},
-          {label: 'Transit other', value: 'transit_other'},
-          {label: 'Train', value: 'train'}
+          {label: 'ground transportation', value: 'ground_transportation'},
+          {label: 'lodging (per night)', value: 'lodging'},{label: 'meals (per diem)', value: 'meals'},
+          {label: 'miscellaneous', value: 'misc'},{label: 'registration fee', value: 'registration'},
+          {label: 'car rental', value: 'rental_vehicle'},
+          {label: 'airfare', value: 'air'},{label: 'taxi', value: 'taxi'},
+          {label: 'mileage - personal car', value: 'personal_auto'},
+          {label: 'other transit', value: 'transit_other'},
+          {label: 'train', value: 'train'}
         ]
       },
       stubs: [

--- a/app/models/estimate.rb
+++ b/app/models/estimate.rb
@@ -2,8 +2,8 @@
 class Estimate < ApplicationRecord
   belongs_to :request
   enum cost_type: {
-    ground_transportation: "ground_transportation",
-    lodging: "lodging",
+    ground_transportation: "ground transportation",
+    lodging: "lodging (per night)",
     meals: "meals (per diem)",
     misc: "miscellaneous",
     registration: "registration fee",

--- a/app/models/estimate.rb
+++ b/app/models/estimate.rb
@@ -4,14 +4,14 @@ class Estimate < ApplicationRecord
   enum cost_type: {
     ground_transportation: "ground_transportation",
     lodging: "lodging",
-    meals: "meals",
-    misc: "misc",
-    registration: "registration",
-    rental_vehicle: "rental_vehicle",
-    air: "air",
+    meals: "meals (per diem)",
+    misc: "miscellaneous",
+    registration: "registration fee",
+    rental_vehicle: "car rental",
+    air: "airfare",
     taxi: "taxi",
-    personal_auto: "personal_auto",
-    transit_other: "transit_other",
+    personal_auto: "mileage - personal car",
+    transit_other: "other transit",
     train: "train"
   }
 end

--- a/app/services/random_request_generator.rb
+++ b/app/services/random_request_generator.rb
@@ -77,7 +77,12 @@ class RandomRequestGenerator
       def generate_random_estimates
         estimates = []
         1.upto(Random.rand(2...10)) do
-          estimates << { amount: Random.rand(10...1000), cost_type: Estimate.cost_types[Estimate.cost_types.keys.sample], recurrence: Random.rand(1...5), description: Faker::Hacker.say_something_smart }
+          estimates << {
+            amount: Random.rand(10...1000),
+            cost_type: Estimate.cost_types[Estimate.cost_types.keys.sample],
+            recurrence: Random.rand(1...5),
+            description: Faker::Hacker.say_something_smart
+          }
         end
         estimates
       end

--- a/app/services/random_request_generator.rb
+++ b/app/services/random_request_generator.rb
@@ -77,7 +77,7 @@ class RandomRequestGenerator
       def generate_random_estimates
         estimates = []
         1.upto(Random.rand(2...10)) do
-          estimates << { amount: Random.rand(10...1000), cost_type: Estimate.cost_types.keys.sample, recurrence: Random.rand(1...5), description: Faker::Hacker.say_something_smart }
+          estimates << { amount: Random.rand(10...1000), cost_type: Estimate.cost_types[Estimate.cost_types.keys.sample], recurrence: Random.rand(1...5), description: Faker::Hacker.say_something_smart }
         end
         estimates
       end

--- a/app/services/random_request_generator.rb
+++ b/app/services/random_request_generator.rb
@@ -79,7 +79,7 @@ class RandomRequestGenerator
         1.upto(Random.rand(2...10)) do
           estimates << {
             amount: Random.rand(10...1000),
-            cost_type: Estimate.cost_types[Estimate.cost_types.keys.sample],
+            cost_type: Estimate.cost_types.keys.sample,
             recurrence: Random.rand(1...5),
             description: Faker::Hacker.say_something_smart
           }

--- a/db/migrate/20191203144321_change_cost_types.rb
+++ b/db/migrate/20191203144321_change_cost_types.rb
@@ -1,0 +1,27 @@
+class ChangeCostTypes < ActiveRecord::Migration[5.2]
+  def up
+    execute <<-SQL
+      ALTER TYPE estimate_cost_type RENAME VALUE 'ground_transportation' TO 'ground transportation';
+      ALTER TYPE estimate_cost_type RENAME VALUE 'lodging' TO 'lodging (per night)';
+      ALTER TYPE estimate_cost_type RENAME VALUE 'meals' TO 'meals (per diem)';
+      ALTER TYPE estimate_cost_type RENAME VALUE 'misc' TO 'miscellaneous';
+      ALTER TYPE estimate_cost_type RENAME VALUE 'registration' TO 'registration fee';
+      ALTER TYPE estimate_cost_type RENAME VALUE 'rental_vehicle' TO 'car rental';
+      ALTER TYPE estimate_cost_type RENAME VALUE 'air' TO 'airfare';
+      ALTER TYPE estimate_cost_type RENAME VALUE 'transit_other' TO 'other transit';
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TYPE estimate_cost_type RENAME VALUE 'ground transportation' TO 'ground_transportation';
+      ALTER TYPE estimate_cost_type RENAME VALUE 'lodging (per night)' TO 'lodging';
+      ALTER TYPE estimate_cost_type RENAME VALUE 'meals (per diem)' TO 'meals';
+      ALTER TYPE estimate_cost_type RENAME VALUE 'miscellaneous' TO 'misc';
+      ALTER TYPE estimate_cost_type RENAME VALUE 'registration fee' TO 'registration';
+      ALTER TYPE estimate_cost_type RENAME VALUE 'car rental' TO 'rental_vehicle';
+      ALTER TYPE estimate_cost_type RENAME VALUE 'airfare' TO 'air';
+      ALTER TYPE estimate_cost_type RENAME VALUE 'other transit' TO 'transit_other';
+    SQL
+  end
+end

--- a/db/migrate/20191203144321_change_cost_types.rb
+++ b/db/migrate/20191203144321_change_cost_types.rb
@@ -3,6 +3,7 @@ class ChangeCostTypes < ActiveRecord::Migration[5.2]
     execute <<-SQL
       ALTER TYPE estimate_cost_type RENAME VALUE 'ground_transportation' TO 'ground transportation';
       ALTER TYPE estimate_cost_type RENAME VALUE 'lodging' TO 'lodging (per night)';
+      ALTER TYPE estimate_cost_type RENAME VALUE 'personal_auto' TO 'mileage - personal car';
       ALTER TYPE estimate_cost_type RENAME VALUE 'meals' TO 'meals (per diem)';
       ALTER TYPE estimate_cost_type RENAME VALUE 'misc' TO 'miscellaneous';
       ALTER TYPE estimate_cost_type RENAME VALUE 'registration' TO 'registration fee';
@@ -16,6 +17,7 @@ class ChangeCostTypes < ActiveRecord::Migration[5.2]
     execute <<-SQL
       ALTER TYPE estimate_cost_type RENAME VALUE 'ground transportation' TO 'ground_transportation';
       ALTER TYPE estimate_cost_type RENAME VALUE 'lodging (per night)' TO 'lodging';
+      ALTER TYPE estimate_cost_type RENAME VALUE 'mileage - personal car' TO 'personal_auto';
       ALTER TYPE estimate_cost_type RENAME VALUE 'meals (per diem)' TO 'meals';
       ALTER TYPE estimate_cost_type RENAME VALUE 'miscellaneous' TO 'misc';
       ALTER TYPE estimate_cost_type RENAME VALUE 'registration fee' TO 'registration';

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -14,16 +14,16 @@ SET row_security = off;
 --
 
 CREATE TYPE public.estimate_cost_type AS ENUM (
-    'ground_transportation',
-    'lodging',
-    'meals',
-    'misc',
-    'registration',
-    'rental_vehicle',
-    'air',
+    'ground transportation',
+    'lodging (per night)',
+    'meals (per diem)',
+    'miscellaneous',
+    'registration fee',
+    'car rental',
+    'airfare',
     'taxi',
     'personal_auto',
-    'transit_other',
+    'other transit',
     'train'
 );
 
@@ -937,6 +937,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191028173311'),
 ('20191029130508'),
 ('20191030122935'),
-('20191125161410');
-
-
+('20191125161410'),
+('20191203144321');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -22,7 +22,7 @@ CREATE TYPE public.estimate_cost_type AS ENUM (
     'car rental',
     'airfare',
     'taxi',
-    'personal_auto',
+    'mileage - personal car',
     'other transit',
     'train'
 );

--- a/spec/controllers/travel_requests_controller_spec.rb
+++ b/spec/controllers/travel_requests_controller_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe TravelRequestsController, type: :controller do
       let(:nested_attributes) do
         {
           notes: [{ creator_id: creator.id, content: "Important message" }],
-          estimates: [amount: 200.20, recurrence: 3, cost_type: "lodging"],
+          estimates: [amount: 200.20, recurrence: 3, cost_type: "lodging (per night)"],
           event_requests: [{ start_date: start_date, location: "Paris", recurring_event_id: recurring_event.id }]
         }
       end
@@ -250,7 +250,7 @@ RSpec.describe TravelRequestsController, type: :controller do
         let(:nested_attributes) do
           {
             notes: [{ creator_id: creator.id, content: "Important message" }],
-            estimates: [id: travel_request.estimates[0].id, amount: 200.20, recurrence: 3, cost_type: "lodging"],
+            estimates: [id: travel_request.estimates[0].id, amount: 200.20, recurrence: 3, cost_type: "lodging (per night)"],
             event_requests: [{ start_date: start_date, location: "Paris", recurring_event_id: recurring_event.id }]
           }
         end

--- a/spec/factories/estimates.rb
+++ b/spec/factories/estimates.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :estimate do
-    cost_type { "lodging" }
+    cost_type { "lodging (per night)" }
     amount { 50.0 }
     recurrence { 3 }
   end


### PR DESCRIPTION
Should we get rid of Ground Transportation altogether? It is used as a grouping in Concur and doesn't really make sense, given the other ground transportation options. We have grouping options in dropdown menus but not input-select components in Lux. If we want to group the cost_type options in this form, we will need to implement the <optgroup> element in Lux's <input-select> component. Thoughts?