### PR TITLE
Adding creator name searching

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -30,7 +30,7 @@ class Request < ApplicationRecord
     query = connection.quote("%#{search_query}%")
 
     # ilike is a case insensitive like
-    joins(:notes).where("notes.content ilike #{query} or event_title ilike #{query}").distinct
+    joins(:creator).joins(:notes).where("notes.content ilike #{query} or event_title ilike #{query} or staff_profiles.given_name ilike #{query} or staff_profiles.surname ilike #{query}").distinct
   end
 
   enum status: {

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -196,4 +196,22 @@ RSpec.describe RequestsController, type: :controller do
       expect(assigns(:requests).count).to eq 1
     end
   end
+
+  describe "GET #my_approval_requests with searching" do
+    it "retrieves a result" do
+      profile = FactoryBot.create :staff_profile, supervisor: staff_profile, given_name: "Haley"
+      absence_request = FactoryBot.create(:absence_request, creator: profile)
+      absence_request2 = FactoryBot.create(:absence_request, creator: profile)
+      travel_request = FactoryBot.create(:travel_request, creator: profile)
+      FactoryBot.create(:note, content: "elephants love balloons", request: absence_request)
+      FactoryBot.create(:note, content: "elephants love pink balloons", request: absence_request2)
+      FactoryBot.create(:note, content: "flamingoes are pink because of shrimp", request: travel_request)
+
+      get :my_approval_requests, params: { query: "balloons" }, session: valid_session
+      expect(assigns(:requests).count).to eq 2
+
+      get :my_approval_requests, params: { query: "haley", filters: { request_type: :travel } }, session: valid_session
+      expect(assigns(:requests).count).to eq 1
+    end
+  end
 end


### PR DESCRIPTION
The event title on the approvals screen was showing the creator name, which was not part of the search.