### PR TITLE
Adding status check before update

### DIFF
--- a/app/change_sets/absence_request_change_set.rb
+++ b/app/change_sets/absence_request_change_set.rb
@@ -22,6 +22,7 @@ class AbsenceRequestChangeSet < Reform::Form
   delegate :vacation_balance, :personal_balance, :sick_balance, :full_name, to: :creator
   delegate :absence_type_icon, :latest_status, :status_color,
            :status_icon, :event_title, :notes_and_changes, :absent_staff,
+           :can_modify_attributes?,
            to: :decorated_model
 
   def balance_title

--- a/app/change_sets/travel_request_change_set.rb
+++ b/app/change_sets/travel_request_change_set.rb
@@ -21,7 +21,7 @@ class TravelRequestChangeSet < Reform::Form
            :status_icon, :event_title, :notes_and_changes, :absent_staff,
            :formatted_full_start_date, :formatted_full_end_date,
            :estimate_fields_json, :estimates_json,
-           :event_attendees,
+           :event_attendees, :can_modify_attributes?,
            to: :decorated_model
 
   attr_reader :current_staff_profile

--- a/app/controllers/absence_requests_controller.rb
+++ b/app/controllers/absence_requests_controller.rb
@@ -8,10 +8,6 @@ class AbsenceRequestsController < CommonRequestController
       AbsenceRequestDecorator
     end
 
-    def can_edit?
-      @request_change_set.model.pending?
-    end
-
     def list_url
       absence_requests_url
     end

--- a/app/controllers/common_request_controller.rb
+++ b/app/controllers/common_request_controller.rb
@@ -17,7 +17,7 @@ class CommonRequestController < ApplicationController
     @request_change_set = request_change_set
 
     # render the default
-    return if can_edit?
+    return if request_change_set.can_modify_attributes?
 
     # handle the error
     respond_with_show_error(message: "#{model_instance_to_name(@request_change_set.model)} can not be edited after it has been #{@request_change_set.model.status}.",
@@ -31,7 +31,12 @@ class CommonRequestController < ApplicationController
 
   # PATCH/PUT
   def update
-    update_model_and_respond(handle_deletes: true, success_verb: "updated", error_action: :edit)
+    if request_change_set.can_modify_attributes?
+      update_model_and_respond(handle_deletes: true, success_verb: "updated", error_action: :edit)
+    else
+      respond_with_show_error(message: "#{model_instance_to_name(@request_change_set.model)} can not be updated after it has been #{@request_change_set.model.status}.",
+                              status: :invalid_update)
+    end
   end
 
   # DELETE

--- a/app/controllers/travel_requests_controller.rb
+++ b/app/controllers/travel_requests_controller.rb
@@ -18,10 +18,6 @@ class TravelRequestsController < CommonRequestController
       TravelRequestDecorator
     end
 
-    def can_edit?
-      @request_change_set.model.pending? || request_change_set.model.changes_requested?
-    end
-
     def list_url
       travel_requests_url
     end

--- a/app/decorators/absence_request_decorator.rb
+++ b/app/decorators/absence_request_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class AbsenceRequestDecorator < RequestDecorator
-  delegate :absence_type, :hours_requested, :vacation_balance, :creator, to: :request
+  delegate :absence_type, :hours_requested, :vacation_balance, :creator, :can_modify_attributes?, to: :request
   delegate :full_name, to: :creator
   attr_reader :absence_request
 

--- a/app/decorators/travel_request_decorator.rb
+++ b/app/decorators/travel_request_decorator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class TravelRequestDecorator < RequestDecorator
   delegate :participation, :purpose, :travel_category,
-           :event_requests, :estimates, :status, to: :request
+           :event_requests, :estimates, :status, :can_modify_attributes?, to: :request
   delegate :full_name, to: :creator
   attr_reader :travel_request
 

--- a/app/models/absence_request.rb
+++ b/app/models/absence_request.rb
@@ -72,4 +72,8 @@ class AbsenceRequest < Request
   def travel_category
     raise_invalid_argument(property_name: :travel_category)
   end
+
+  def can_modify_attributes?
+    pending?
+  end
 end

--- a/app/models/travel_request.rb
+++ b/app/models/travel_request.rb
@@ -72,4 +72,8 @@ class TravelRequest < Request
   def start_time
     raise_invalid_argument(property_name: :start_time)
   end
+
+  def can_modify_attributes?
+    changes_requested? || pending? && state_changes.empty?
+  end
 end

--- a/spec/controllers/absence_requests_controller_spec.rb
+++ b/spec/controllers/absence_requests_controller_spec.rb
@@ -374,6 +374,16 @@ RSpec.describe AbsenceRequestsController, type: :controller do
         end.to change(Note, :count).by(0)
       end
     end
+
+    context "Already in the approval process" do
+      it "does not allow updates to the attributes" do
+        absence_request.approve(agent: absence_request.creator.supervisor)
+        absence_request.save
+        put :update, params: { id: absence_request.to_param, absence_request: valid_attributes }, session: valid_session
+        expect(response).to redirect_to(absence_request)
+        expect(absence_request.reload.absence_type).not_to eq("sick")
+      end
+    end
   end
 
   describe "DELETE #destroy" do


### PR DESCRIPTION
Moved the check for attribute update to the model so it could be reused

Also changes the travel check to make sure that the pending status is not because it has been approved, but not fully.