### PR TITLE
Switching development and staging to point to mailcatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,17 @@ This is an application that allows the library to create workflows that allow st
      ```
      bundle exec foreman start
      ```
-
+   * run mail catcher
+     run once 
+     ```
+     gem install mailcatcher
+     ```
+     run every time
+     ```
+     mailcatcher
+     ```
    
+     [you can see the mail that has been sent here]( http://localhost:1080/)
      
 ## How to run the test suite
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,9 +31,14 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  # config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    :address => "localhost", 
+    :port => 1025
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -65,6 +65,12 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    :address => "localhost", 
+    :port => 1025
+  }
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
Also update the readme for local installation of mailcatcher

The mailcatcher instructuions specifically say not to put the gem in the Gemfile, which is why I updated the README instead.

Staging is set up via ansible: https://github.com/pulibrary/princeton_ansible/pull/1079