### PR TITLE
Do not allow someone being a delegate to create or assume delegates

### DIFF
--- a/app/controllers/delegates_controller.rb
+++ b/app/controllers/delegates_controller.rb
@@ -2,6 +2,7 @@
 class DelegatesController < ApplicationController
   before_action :set_delegate, only: [:destroy]
   before_action :set_delegator, only: [:assume]
+  before_action :check_for_delegation, only: [:assume, :create, :destroy]
 
   # GET /delegates
   # GET /delegates.json
@@ -100,5 +101,15 @@ class DelegatesController < ApplicationController
 
       # the delegator can only be the logged in user
       permitted_params.merge(delegator_id: current_staff_profile.id)
+    end
+
+    def check_for_delegation
+      return unless current_delegate
+
+      respond_to do |format|
+        format.html { redirect_to my_requests_path, notice: "You can not modify delegations as a delegate" }
+        format.json { head :no_content }
+      end
+      false
     end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,8 +17,10 @@
         <% if current_user %>
           {name: 'My Requests', component: 'My Requests', href: '/my_requests/'},
           <%= "{name: 'Requests to Review', component: 'Requests to Review', href: '/my_approval_requests/'}," if current_staff_profile.supervisor? %>
-          {name: 'My Delegates', component: 'My Delegates', href: '/delegates/'},
-          {name: 'Delegations', component: 'Delegations', href: '<%= to_assume_delegates_path %>'},
+          <% unless current_delegate %>
+            {name: 'My Delegates', component: 'My Delegates', href: '/delegates/'},
+            {name: 'Delegations', component: 'Delegations', href: '<%= to_assume_delegates_path %>'},
+          <% end %>
           {name: 'Logout', component: 'Logout', href: '/sign_out'}
         <% end %>
       ]"/>

--- a/spec/features/delegate_spec.rb
+++ b/spec/features/delegate_spec.rb
@@ -10,6 +10,7 @@ RSpec.feature "Delegate", type: :feature, js: true do
 
   before do
     sign_in user
+    delegate
   end
 
   scenario "I can see my requests and my delegates" do
@@ -19,12 +20,21 @@ RSpec.feature "Delegate", type: :feature, js: true do
 
     visit "/my_requests"
     assert_selector ".my-request .lux-card", count: 1
+    assert_selector "a", text: "Delegations", count: 1
+    assert_selector "a", text: "My Delegates", count: 1
 
-    # Todo we really should not need to hand jam the url
-    visit assume_delegate_path(delegate)
+    click_on "Delegations"
+    Percy.snapshot(page, name: "Delegations - Show", widths: [375, 768, 1440])
+
+    assert_selector ".lux-card-header", text: /^Joe Schmo*/, count: 1
+    assert_selector ".lux-card-content a", count: 1
+
+    find(".lux-card-content a").click
 
     assert_selector "div.lux-alert", text: "You are acting on behalf of #{delegate_staff_profile}"
     assert_selector ".my-request .lux-card", count: 2
+    assert_selector "a", text: "Delegations", count: 0
+    assert_selector "a", text: "My Delegates", count: 0
 
     click_link "New leave request"
     assert_selector "div.lux-alert", text: "You are acting on behalf of #{delegate_staff_profile}"


### PR DESCRIPTION
This adds a new Percy snapshot of the Delegations page.