### PR TITLE
Change config to not pretend everywhere is production

### DIFF
--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -1,3 +1,2 @@
 ---
 api_key: '26617ea2'
-env: 'production'


### PR DESCRIPTION
I realized this setting was not saying only run in production, but saying pretend everywhere is production.  Errors were being reported this morning from when my tests failed.