### PR TITLE
Changing controller to not raise error on second cancel

### DIFF
--- a/app/controllers/common_request_controller.rb
+++ b/app/controllers/common_request_controller.rb
@@ -172,7 +172,7 @@ class CommonRequestController < ApplicationController
     end
 
     def creator_can_change?(action:)
-      allowed_to_change = request_change_set.model.only_creator(agent: current_staff_profile)
+      allowed_to_change = request_change_set.model.can_edit?(agent: current_staff_profile)
       respond_to_change_error(action: action, allowed_to_change: allowed_to_change)
     end
 

--- a/app/models/concerns/aasm_config.rb
+++ b/app/models/concerns/aasm_config.rb
@@ -52,6 +52,14 @@ module AasmConfig
     creator == agent
   end
 
+  def can_cancel?(agent:)
+    only_creator(agent: agent) && !canceled?
+  end
+
+  def can_edit?(agent:)
+    only_creator(agent: agent) && can_modify_attributes?
+  end
+
   private
 
     def in_supervisor_chain(supervisor:, agent:, previous_supervisor: "no one")

--- a/app/views/absence_requests/show.html.erb
+++ b/app/views/absence_requests/show.html.erb
@@ -20,8 +20,10 @@
   </grid-container>
   <grid-container>
     <grid-item>
-      <% if @request.creator == current_staff_profile %>
+      <% if @request.request.can_edit?(agent: current_staff_profile) %>
         <hyperlink href="<%= edit_absence_request_path(@request.request) %>" variation="button solid">Edit</hyperlink>
+      <% end %>
+      <% if @request.request.can_cancel?(agent: current_staff_profile) %>
         <%= form_with(model: @request.request, local: true, url: decide_absence_request_path(@request.request), method: :put, class: 'form-button') do |form| %>
           <input-button type="submit" variation="solid" name="cancel">Cancel</input-button>
         <% end %>

--- a/app/views/travel_requests/show.html.erb
+++ b/app/views/travel_requests/show.html.erb
@@ -69,10 +69,12 @@
       </card>
     </grid-item>
     <grid-item>
-      <% if @request.creator == current_staff_profile %>
+      <% if @request.request.can_edit?(agent: current_staff_profile) %>
         <hyperlink
           href="<%= edit_travel_request_path(@request.id) %>"
           variation="button solid"
+      <% end %>
+      <% if @request.request.can_cancel?(agent: current_staff_profile) %>
           >Edit</hyperlink>
         <%= form_with(model: @request.request, local: true, url: decide_travel_request_path(@request.id), method: :put, class: 'form-button') do |form| %>
           <input-button type="submit" variation="solid" name="cancel">Cancel</input-button>

--- a/spec/controllers/travel_requests_controller_spec.rb
+++ b/spec/controllers/travel_requests_controller_spec.rb
@@ -534,13 +534,20 @@ RSpec.describe TravelRequestsController, type: :controller do
       travel_request = FactoryBot.create(:travel_request, creator: creator)
       notes = { notes: [{ content: "Important message" }] }
       put :decide, params: { id: travel_request.to_param, travel_request: notes, cancel: "" }, session: valid_session
-      travel_request.reload
-      expect(travel_request).to be_canceled
-      expect(travel_request.notes.count).to eq 1
+      expect(response).to redirect_to(travel_request)
+      expect(assigns(:request)).to eq(travel_request)
     end
 
     it "cancels and returns a success response" do
       travel_request = FactoryBot.create(:travel_request, creator: creator)
+      put :decide, params: { id: travel_request.to_param, cancel: "" }, session: valid_session
+      travel_request.reload
+      expect(travel_request.notes.count).to eq 0
+      expect(travel_request).to be_canceled
+    end
+
+    it "does not cancel a canceled request" do
+      travel_request = FactoryBot.create(:travel_request, creator: creator, action: :cancel)
       put :decide, params: { id: travel_request.to_param, cancel: "" }, session: valid_session
       travel_request.reload
       expect(travel_request.notes.count).to eq 0

--- a/spec/features/new_absence_request_spec.rb
+++ b/spec/features/new_absence_request_spec.rb
@@ -37,5 +37,7 @@ RSpec.feature "New Leave Request", type: :feature, js: true do
     expect(page).to have_content "Sick Leave"
     expect(page).to have_content "Total Hours\n21.75"
     expect(page).to have_content "Canceled"
+    expect(page).not_to have_selector(:link_or_button, "Edit")
+    expect(page).not_to have_selector(:link_or_button, "Cancel")
   end
 end

--- a/spec/features/new_travel_request_spec.rb
+++ b/spec/features/new_travel_request_spec.rb
@@ -47,5 +47,7 @@ RSpec.feature "New Leave Request", type: :feature, js: true do
     expect(page).to have_content "Super Event 2019, A Place To Be (10/01/2019 to 10/03/2019)"
     expect(page).to have_content "air 2 20.00 40.00\nlodging 3 30.00 90.00\nTotal: 130.00"
     expect(page).to have_content "Canceled"
+    expect(page).not_to have_selector(:link_or_button, "Edit")
+    expect(page).not_to have_selector(:link_or_button, "Cancel")
   end
 end


### PR DESCRIPTION
Also remove the edit and cancel buttons on the page when the user can not edit or cancel.