### PR TITLE
Changing to be able to edit a request after changes have been requested

### DIFF
--- a/app/decorators/request_decorator.rb
+++ b/app/decorators/request_decorator.rb
@@ -123,7 +123,7 @@ class RequestDecorator
 
     def decorated_status
       if (status == "pending") && state_changes.count.positive?
-        "Pending further approval"
+        "Pending further review"
       else
         status.humanize
       end

--- a/app/models/state_change.rb
+++ b/app/models/state_change.rb
@@ -17,7 +17,7 @@ class StateChange < ApplicationRecord
   }
 
   def title
-    "#{action.titleize} by #{actor_and_date}"
+    "#{title_for_action} by #{actor_and_date}"
   end
 
   def actor_and_date
@@ -28,4 +28,12 @@ class StateChange < ApplicationRecord
       "#{agent.full_name} on #{date}"
     end
   end
+
+  private
+
+    def title_for_action
+      return "Updated" if pending?
+
+      action.titleize
+    end
 end

--- a/app/models/travel_request.rb
+++ b/app/models/travel_request.rb
@@ -74,6 +74,6 @@ class TravelRequest < Request
   end
 
   def can_modify_attributes?
-    changes_requested? || pending? && state_changes.empty?
+    changes_requested? || (pending? && (state_changes.empty? || state_changes.last.pending?))
   end
 end

--- a/spec/controllers/travel_requests_controller_spec.rb
+++ b/spec/controllers/travel_requests_controller_spec.rb
@@ -124,6 +124,14 @@ RSpec.describe TravelRequestsController, type: :controller do
       assert_equal travel_request, assigns(:request_change_set).model
     end
 
+    it "can edit a fix_requested_changes pending request" do
+      travel_request = FactoryBot.create(:travel_request, creator: creator, action: "fix_requested_changes")
+      get :edit, params: { id: travel_request.to_param }, session: valid_session
+      expect(response).to be_successful
+      expect(assigns(:request_change_set)).to be_a(TravelRequestChangeSet)
+      assert_equal travel_request, assigns(:request_change_set).model
+    end
+
     it "can not edit an approved request" do
       travel_request = FactoryBot.create(:travel_request, creator: creator, action: "approve")
       get :edit, params: { id: travel_request.to_param }, session: valid_session

--- a/spec/decorators/travel_request_decorator_spec.rb
+++ b/spec/decorators/travel_request_decorator_spec.rb
@@ -127,12 +127,12 @@ RSpec.describe TravelRequestDecorator, type: :model do
       end
     end
 
-    context "approved but waiting on further approval" do
+    context "approved but waiting on further review" do
       let(:creator) { FactoryBot.create :staff_profile, :with_supervisor }
       let(:travel_request) { FactoryBot.create(:travel_request, creator: creator) }
-      it "returns pending futher approval" do
+      it "returns pending futher review" do
         travel_request.approve!(agent: travel_request.creator.supervisor)
-        expect(travel_request_decorator.latest_status).to eq "Pending further approval"
+        expect(travel_request_decorator.latest_status).to eq "Pending further review"
         expect(travel_request_decorator.latest_status_date).to eq "Updated on #{today.strftime('%m/%d/%Y')}"
       end
     end
@@ -192,6 +192,7 @@ RSpec.describe TravelRequestDecorator, type: :model do
         request.notes << FactoryBot.build(:note, content: "looks good", creator: supervisor)
         request.change_request(agent: department_head)
         request.notes << FactoryBot.build(:note, content: "change stuff", creator: department_head)
+        request.fix_requested_changes(agent: staff)
         request
       end
 
@@ -208,7 +209,9 @@ RSpec.describe TravelRequestDecorator, type: :model do
                                                                    { title: "Changes Requested by Department Head on #{Time.zone.now.strftime('%m/%d/%Y')}", content: nil,
                                                                      icon: "refresh" },
                                                                    { title: "Department Head on #{Time.zone.now.strftime('%m/%d/%Y')}", content: "change stuff",
-                                                                     icon: "note" }
+                                                                     icon: "note" },
+                                                                   { title: "Updated by Staff Person on #{Time.zone.now.strftime('%m/%d/%Y')}", content: nil,
+                                                                     icon: "clock" }
                                                                  ])
       end
     end

--- a/spec/models/state_change_spec.rb
+++ b/spec/models/state_change_spec.rb
@@ -12,4 +12,19 @@ RSpec.describe StateChange, type: :model do
     it { is_expected.to respond_to :delegate_id }
     it { is_expected.to respond_to :delegate }
   end
+
+  describe "#title" do
+    it "returns the title for a canceled request" do
+      agent = FactoryBot.create :staff_profile, surname: "Doe", given_name: "Jane"
+      state_change = FactoryBot.create :state_change, action: "canceled", agent: agent
+      expect(state_change.title).to start_with("Canceled by Jane Doe")
+    end
+
+    it "returns the title for a fixed request" do
+      agent = FactoryBot.create :staff_profile, :with_department, surname: "Doe", given_name: "Jane"
+      request = FactoryBot.create :travel_request, creator: agent, action: "fix_requested_changes"
+      state_change = request.state_changes.last
+      expect(state_change.title).to start_with("Updated by Jane Doe")
+    end
+  end
 end


### PR DESCRIPTION
Also changes the title of the state change from Pending by to Updated by
Changes "Pending further approval" to "Pending further review" to match with email and be more accurate when no approval has yet occurred

refs #503

Co-authored-by: Shaun Ellis <shaun@sdellis.com>