### PR TITLE
[WIP] Refactors main menu and request type filter to use children

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,14 +16,18 @@
     <library-header app-name="Leave and Travel Requests" app-url="<%= HomeURL.for(current_user: current_user) %>" class="lux" :max-width=1440 theme="dark">
     <menu-bar type="links" :menu-items="[
         <% if current_user %>
-          {name: 'My Requests', component: 'My Requests', href: '/my_requests/'},
+          {name: 'My Requests', component: 'My Requests', href: '/my_requests/', children: [
+            {name: 'New Travel Request', component: 'New Travel Request', href: '/travel_requests/new/'},
+          ]},
           <%= "{name: 'Requests to Review', component: 'Requests to Review', href: '/my_approval_requests/'}," if current_staff_profile.supervisor? %>
-          <% unless current_delegate %>
-            {name: 'My Delegates', component: 'My Delegates', href: '/delegates/'},
-            {name: 'Delegations', component: 'Delegations', href: '<%= to_assume_delegates_path %>'},
-          <% end %>
-          {name: 'Help', component: 'Help', href: '/help'},
-          {name: 'Logout', component: 'Logout', href: '/sign_out'}
+          {name: 'My Account', component: 'My Account', href: '#', children: [
+            <% unless current_delegate %>
+              {name: 'My Delegates', component: 'My Delegates', href: '/delegates/'},
+              {name: 'Delegations', component: 'Delegations', href: '<%= to_assume_delegates_path %>'},
+            <% end %>
+            {name: 'Logout', component: 'Logout', href: '/sign_out'}
+          ]},
+          {name: 'Help', component: 'Help', href: '/help'}
         <% end %>
       ]"/>
     </library-header>

--- a/app/views/requests/_record_list.html.erb
+++ b/app/views/requests/_record_list.html.erb
@@ -23,14 +23,16 @@
               <% end %>
 
               <dropdown-menu type="links" id="request-type-menu" button-label="<%= @requests.current_request_type_filter_label %>" :menu-items="[
-                {name: 'Absence', component: 'Absence', href: '<%= @requests.absence_filter_url %>'},
-                <% @requests.absence_filter_urls.each do |key, url| %>
-                  {name: '<%= key %>', component: '<%= key %>', parent: 'Absence', href: '<%= url %>'},
-                <% end %>
-                {name: 'Travel', component: 'Travel', href: '<%= @requests.travel_filter_url %>'},
-                <% @requests.travel_filter_urls.each do |key, url| %>
-                  {name: '<%= key %>', component: '<%= key %>', parent: 'Travel', href: '<%= url %>'},
-                <% end %>
+                {name: 'Absence', component: 'Absence', href: '<%= @requests.absence_filter_url %>', children: [
+                  <% @requests.absence_filter_urls.each do |key, url| %>
+                    {name: '<%= key %>', component: '<%= key %>', href: '<%= url %>'},
+                  <% end %>
+                ]},
+                {name: 'Travel', component: 'Travel', href: '<%= @requests.travel_filter_url %>', children: [
+                  <% @requests.travel_filter_urls.each do |key, url| %>
+                    {name: '<%= key %>', component: '<%= key %>', href: '<%= url %>'},
+                  <% end %>
+                ]},
               ]"></dropdown-menu>
 
               <dropdown-menu type="links" id="department-menu" button-label="<%= @requests.current_department_filter_label %>" :menu-items="[

--- a/app/views/requests/_report_list.html.erb
+++ b/app/views/requests/_report_list.html.erb
@@ -23,14 +23,16 @@
               <% end %>
 
               <dropdown-menu type="links" id="request-type-menu" button-label="<%= @requests.current_request_type_filter_label %>" :menu-items="[
-                {name: 'Absence', component: 'Absence', href: '<%= @requests.absence_filter_url %>'},
-                <% @requests.absence_filter_urls.each do |key, url| %>
-                  {name: '<%= key %>', component: '<%= key %>', parent: 'Absence', href: '<%= url %>'},
-                <% end %>
-                {name: 'Travel', component: 'Travel', href: '<%= @requests.travel_filter_url %>'},
-                <% @requests.travel_filter_urls.each do |key, url| %>
-                  {name: '<%= key %>', component: '<%= key %>', parent: 'Travel', href: '<%= url %>'},
-                <% end %>
+                {name: 'Absence', component: 'Absence', href: '<%= @requests.absence_filter_url %>', children: [
+                  <% @requests.absence_filter_urls.each do |key, url| %>
+                    {name: '<%= key %>', component: '<%= key %>', href: '<%= url %>'},
+                  <% end %>
+                ]},
+                {name: 'Travel', component: 'Travel', href: '<%= @requests.travel_filter_url %>', children: [
+                  <% @requests.travel_filter_urls.each do |key, url| %>
+                    {name: '<%= key %>', component: '<%= key %>', href: '<%= url %>'},
+                  <% end %>
+                ]},
               ]"></dropdown-menu>
 
               <dropdown-menu type="links" id="department-menu" button-label="<%= @requests.current_department_filter_label %>" :menu-items="[

--- a/app/views/requests/_request_list.html.erb
+++ b/app/views/requests/_request_list.html.erb
@@ -23,14 +23,16 @@
               <% end %>
 
               <dropdown-menu type="links" id="request-type-menu" button-label="<%= @requests.current_request_type_filter_label %>" :menu-items="[
-                <!-- {name: 'Absence', component: 'Absence', href: '<%= @requests.absence_filter_url %>'},
-                <% @requests.absence_filter_urls.each do |key, url| %>
-                  {name: '<%= key %>', component: '<%= key %>', parent: 'Absence', href: '<%= url %>'},
-                <% end %> -->
-                {name: 'Travel', component: 'Travel', href: '<%= @requests.travel_filter_url %>'},
-                <% @requests.travel_filter_urls.each do |key, url| %>
-                  {name: '<%= key %>', component: '<%= key %>', parent: 'Travel', href: '<%= url %>'},
-                <% end %>
+                {name: 'Absence', component: 'Absence', href: '<%= @requests.absence_filter_url %>', children: [
+                  <% @requests.absence_filter_urls.each do |key, url| %>
+                    {name: '<%= key %>', component: '<%= key %>', href: '<%= url %>'},
+                  <% end %>
+                ]},
+                {name: 'Travel', component: 'Travel', href: '<%= @requests.travel_filter_url %>', children: [
+                  <% @requests.travel_filter_urls.each do |key, url| %>
+                    {name: '<%= key %>', component: '<%= key %>', href: '<%= url %>'},
+                  <% end %>
+                ]}
               ]"></dropdown-menu>
             </grid-item>
             <grid-item columns="sm-12 auto">

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/webpacker": "^4.0.2",
-    "lux-design-system": "^2.14.0",
+    "lux-design-system": "^2.15",
     "vue": "^2.6.10",
     "vue-loader": "^15.7.0",
     "vue-template-compiler": "^2.6.10"

--- a/spec/features/delegate_spec.rb
+++ b/spec/features/delegate_spec.rb
@@ -20,10 +20,12 @@ RSpec.feature "Delegate", type: :feature, js: true do
 
     visit "/my_requests"
     assert_selector ".my-request .lux-card", count: 1
-    assert_selector "a", text: "Delegations", count: 1
-    assert_selector "a", text: "My Delegates", count: 1
+    assert_selector "a", text: "Delegations", count: 0
+    assert_selector "a", text: "My Delegates", count: 0
 
+    click_on "My Account"
     click_on "Delegations"
+
     Percy.snapshot(page, name: "Delegations - Show", widths: [375, 768, 1440])
 
     assert_selector ".lux-card-header", text: /^Joe Schmo*/, count: 1
@@ -40,8 +42,6 @@ RSpec.feature "Delegate", type: :feature, js: true do
     assert_selector "div.lux-alert", text: "You are acting on behalf of #{delegate_staff_profile}"
     assert_selector ".my-request .lux-card", count: 2
 
-    # Todo we really should not need to hand jam the url
-    # visit cancel_delegates_path
     find("a#cancel_delegation").click
 
     assert_selector "div.lux-alert", text: "You are now acting on your own behalf"
@@ -55,11 +55,11 @@ RSpec.feature "Delegate", type: :feature, js: true do
 
     visit "/my_requests"
     assert_selector ".my-request .lux-card", count: 1
-    assert_selector "a", text: "Delegations", count: 1
-    assert_selector "a", text: "My Delegates", count: 1
+    assert_selector "a", text: "Delegations", count: 0
+    assert_selector "a", text: "My Delegates", count: 0
 
+    click_on "My Account"
     click_on "Delegations"
-    Percy.snapshot(page, name: "Delegations - Show", widths: [375, 768, 1440])
 
     assert_selector ".lux-card-header", text: /^Joe Schmo*/, count: 1
     assert_selector ".lux-card-header a", count: 1
@@ -86,8 +86,6 @@ RSpec.feature "Delegate", type: :feature, js: true do
     assert_selector "div.lux-alert", text: "You are acting on behalf of #{delegate_staff_profile}"
     assert_selector ".my-request .lux-card", count: 3
 
-    # Todo we really should not need to hand jam the url
-    # visit cancel_delegates_path
     find("a#cancel_delegation").click
 
     assert_selector "div.lux-alert", text: "You are now acting on your own behalf"


### PR DESCRIPTION
Blocked by https://github.com/pulibrary/lux/pull/295

Tests are failing and LUX version needs to be bumped up for this to work.

I was unable to comment out the absence request types in the request list. Maybe we can just remove it for now since the code is version controlled.

I was also not sure about the IA of the main menu. I put "New travel request" under "My requests". Feel free to refactor.