### PR TITLE
Enhances mobile view of review screen

### DIFF
--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -23,3 +23,13 @@ body {
 .lux-alert ul {
   margin: 1rem 0 0 2rem;
 }
+
+@media (max-width: 599px) {
+  .lux-button {
+    width: 100%;
+  }
+
+  .sm-12.auto {
+    flex-basis: 100%;
+  }
+}

--- a/app/assets/stylesheets/_card.scss
+++ b/app/assets/stylesheets/_card.scss
@@ -30,6 +30,23 @@
     float: left;
     margin-right: 1rem;
   }
+
+  .title-card.full-width .lux-card-media+.lux-card-header {
+    padding-left: 1rem;
+    flex-basis: 100%;
+  }
+
+  .title-card .lux-card-media {
+    order: 1;
+  }
+  .title-card .lux-card-content {
+    order: 2;
+    margin-left: auto;
+  }
+  .title-card .lux-card-header {
+    order: 3;
+    width: 100%;
+  }
 }
 
 .request .lux-card,

--- a/app/assets/stylesheets/_estimates.scss
+++ b/app/assets/stylesheets/_estimates.scss
@@ -42,8 +42,11 @@
 .travel-estimates tr:last-child td,
 .expense-total .lux-text-style {
   font-weight: bold;
-  font-size: 28px;
   line-height: 1;
+
+  @media (min-width: 600px) {
+    font-size: 28px;
+  }
 }
 
 .lux-card-content .lux-data-table {


### PR DESCRIPTION
Fixes header spacing and changes order of card content:
<img width="393" alt="Screen Shot 2020-02-10 at 12 12 10 PM" src="https://user-images.githubusercontent.com/8161144/74172783-d412ce00-4bfe-11ea-90a8-e7963cece48b.png">

Makes total anticipated expenses smaller font so it doesn't get cut off and stretches buttons to be full width:
<img width="351" alt="Screen Shot 2020-02-10 at 12 12 21 PM" src="https://user-images.githubusercontent.com/8161144/74172837-f0166f80-4bfe-11ea-93af-09099270afae.png">
