### PR TITLE
Catch parse error on dates

### DIFF
--- a/app/change_sets/travel_request_change_set.rb
+++ b/app/change_sets/travel_request_change_set.rb
@@ -4,6 +4,10 @@ class TravelRequestChangeSet < RequestChangeSet
   property :purpose
   property :participation
 
+  # to allow for error messages to be attached to the form fields
+  property :travel_dates
+  property :event_dates
+
   collection :event_requests, form: EventRequestChangeSet, populator: EventRequestChangeSet::EventRequestPopulator, prepopulator: EventRequestChangeSet::EventRequestPrepopulator
   collection :estimates, form: EstimateChangeSet, populator: EstimateChangeSet::EstimatePopulator
 

--- a/app/controllers/travel_requests_controller.rb
+++ b/app/controllers/travel_requests_controller.rb
@@ -56,6 +56,10 @@ class TravelRequestsController < CommonRequestController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def travel_request_params
+      @travel_request_params ||= clean_and_require_params
+    end
+
+    def clean_and_require_params
       clean_params
       params.require(:travel_request).permit(
         :creator_id,
@@ -95,7 +99,13 @@ class TravelRequestsController < CommonRequestController
       return if hash.blank? || hash[field].blank?
       dates = hash[field].split(" - ")
       hash[:start_date] = Date.strptime(dates[0], "%m/%d/%Y")
-      hash[:end_date] = Date.strptime(dates[1], "%m/%d/%Y")
+      hash[:end_date] = if dates.length == 2
+                          Date.strptime(dates[1], "%m/%d/%Y")
+                        else
+                          hash[:start_date]
+                        end
+    rescue ArgumentError
+      request_change_set.errors.add(field, "must be in a valid format (mm/dd/yyyy)")
     end
 
     def processed_params

--- a/app/models/travel_request.rb
+++ b/app/models/travel_request.rb
@@ -5,6 +5,8 @@
 class TravelRequest < Request
   include AasmConfig
 
+  attr_accessor :travel_dates, :event_dates # to allow for error messages to be attached to the form fields
+
   def to_s
     "#{creator}  #{event_requests.first.recurring_event.name}"
   end

--- a/app/views/travel_requests/_form.html.erb
+++ b/app/views/travel_requests/_form.html.erb
@@ -1,15 +1,7 @@
 
 <%= form_with(model: request_change_set.model, local: true) do |form| %>
 <% if request_change_set.errors.any? %>
-  <div id="error_explanation">
-    <h2><%= pluralize(request_change_set.errors.count, "error") %> prohibited this request from being saved:</h2>
-
-    <ul>
-    <% request_change_set.errors.full_messages.each do |message| %>
-      <li><%= message %></li>
-    <% end %>
-    </ul>
-  </div>
+  <%=render 'errors', request_change_set: request_change_set %>
 <% end %>
 <grid-container>
   <grid-item columns="lg-12 sm-12">

--- a/spec/controllers/travel_requests_controller_spec.rb
+++ b/spec/controllers/travel_requests_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe TravelRequestsController, type: :controller do
   end
 
   let(:invalid_attributes) do
-    { participation: "", purpose: "Travel to campus for in-person meetings" }
+    { participation: "", purpose: "Travel to campus for in-person meetings", travel_dates: "N/A" }
   end
 
   # This should return the minimal set of values that should be in the session
@@ -298,7 +298,8 @@ RSpec.describe TravelRequestsController, type: :controller do
         expect(response).to be_successful
         expect(assigns(:request_change_set)).to be_a(TravelRequestChangeSet)
         expect(assigns(:request_change_set).errors.messages).to eq(event_requests: ["can't be blank"],
-                                                                   participation: ["is not included in the list"])
+                                                                   participation: ["is not included in the list"],
+                                                                   travel_dates: ["must be in a valid format (mm/dd/yyyy)"])
         expect(assigns(:request_change_set).model.purpose).to eq("Travel to campus for in-person meetings")
       end
     end
@@ -484,7 +485,8 @@ RSpec.describe TravelRequestsController, type: :controller do
         travel_request = FactoryBot.create(:travel_request, creator: staff_profile)
         put :decide, params: { id: travel_request.to_param, travel_request: invalid_attributes, approve: "" }, session: valid_session
         expect(response).to be_successful
-        expect(assigns(:request_change_set).errors.messages).to eq(participation: ["is not included in the list"])
+        expect(assigns(:request_change_set).errors.messages).to eq(participation: ["is not included in the list"],
+                                                                   travel_dates: ["must be in a valid format (mm/dd/yyyy)"])
         travel_request.reload
         expect(travel_request).to be_pending
       end
@@ -516,7 +518,9 @@ RSpec.describe TravelRequestsController, type: :controller do
         travel_request = FactoryBot.create(:travel_request, creator: staff_profile)
         put :decide, params: { id: travel_request.to_param, travel_request: invalid_attributes, deny: "" }, session: valid_session
         expect(response).to be_successful
-        expect(assigns(:request_change_set).errors.messages).to eq(participation: ["is not included in the list"], notes: ["are required to deny a request"])
+        expect(assigns(:request_change_set).errors.messages).to eq(participation: ["is not included in the list"],
+                                                                   notes: ["are required to deny a request"],
+                                                                   travel_dates: ["must be in a valid format (mm/dd/yyyy)"])
         travel_request.reload
         expect(travel_request).to be_pending
       end
@@ -548,7 +552,9 @@ RSpec.describe TravelRequestsController, type: :controller do
         travel_request = FactoryBot.create(:travel_request, creator: staff_profile)
         put :decide, params: { id: travel_request.to_param, travel_request: invalid_attributes, change_request: "" }, session: valid_session
         expect(response).to be_successful
-        expect(assigns(:request_change_set).errors.messages).to eq(participation: ["is not included in the list"], notes: ["are required to specify requested changes."])
+        expect(assigns(:request_change_set).errors.messages).to eq(participation: ["is not included in the list"],
+                                                                   travel_dates: ["must be in a valid format (mm/dd/yyyy)"],
+                                                                   notes: ["are required to specify requested changes."])
         travel_request.reload
         expect(travel_request).to be_pending
       end


### PR DESCRIPTION
Change the model and changeset to allow for an error to be set on event_dates and travel_dates, which are in the form, but not in the database
update the error view to use the new partial that looks better