### PR TITLE
Allowing travel category to be optional

### DIFF
--- a/app/change_sets/travel_request_change_set.rb
+++ b/app/change_sets/travel_request_change_set.rb
@@ -15,7 +15,7 @@ class TravelRequestChangeSet < RequestChangeSet
   validates :event_requests, presence: true
   validates :participation, inclusion: { in: Request.participations.keys }
 
-  delegate :travel_category_icon,
+  delegate :travel_category_icon, :current_note,
            :estimate_fields_json, :estimates_json,
            to: :decorated_model
 

--- a/app/controllers/travel_requests_controller.rb
+++ b/app/controllers/travel_requests_controller.rb
@@ -8,6 +8,7 @@ class TravelRequestsController < CommonRequestController
       request_change_set.errors.add(:notes, "are required to specify requested changes.") if processed_params[:notes].blank?
       run_action(action: :change_request, change_method: :supervisor_can_change?)
     else
+      request_change_set.errors.add(:travel_category, "is required to approve.") if params[:approve] && processed_params[:travel_category].blank? && current_staff_profile.department_head?
       super
     end
   end

--- a/app/decorators/request_decorator.rb
+++ b/app/decorators/request_decorator.rb
@@ -78,10 +78,16 @@ class RequestDecorator
   def notes_and_changes
     both = notes.to_a
     delegate_note = both.shift if created_by_delegate
+    both.pop if both.last && both.last.created_at.blank?
     both.concat(state_changes.to_a)
     both = both.sort_by(&:created_at)
     json = both.map { |item| item_json(item) }
     created_state(json: json, delegate_note: delegate_note)
+  end
+
+  def current_note
+    return "" unless notes.last && notes.last.created_at.blank?
+    notes.last.content
   end
 
   def last_supervisor_to_approve

--- a/app/views/travel_requests/_notes_card.html.erb
+++ b/app/views/travel_requests/_notes_card.html.erb
@@ -9,7 +9,7 @@
         </ul>
 
     <% if render_edit %>
-      <input-text id="travel_request_notes_content" name="travel_request[notes][content]" label="Notes" type="textarea" maxlength="9999" rows="10" width="expand"></input-text>
+      <input-text id="travel_request_notes_content" name="travel_request[notes][content]" label="Notes" type="textarea" maxlength="9999" rows="10" width="expand" value="<%= request.current_note%>" ></input-text>
     <% end %>
     </card-content>
   </card>

--- a/app/views/travel_requests/_review_form.html.erb
+++ b/app/views/travel_requests/_review_form.html.erb
@@ -35,7 +35,7 @@
               <input-select label="Travel Category" name="travel_request[travel_category]"
                   id="travel_request_travel_category" width="expand"
                   value="<%= request_change_set.travel_category %>"
-                  :options="<%= request_change_set.travel_category_options %>" required=true></input-select>
+                  :options="<%= request_change_set.travel_category_options %>"></input-select>
             <% end %>
           </card-content>
         </card>

--- a/spec/controllers/travel_requests_controller_spec.rb
+++ b/spec/controllers/travel_requests_controller_spec.rb
@@ -462,11 +462,23 @@ RSpec.describe TravelRequestsController, type: :controller do
       staff_profile.department.head = creator
       staff_profile.department.save
       travel_request = FactoryBot.create(:travel_request, creator: staff_profile)
-      notes = { notes: [{ content: "Important message" }] }
+      notes = { notes: [{ content: "Important message" }], travel_category: "business" }
       put :decide, params: { id: travel_request.to_param, travel_request: notes, approve: "" }, session: valid_session
       travel_request.reload
       expect(travel_request.notes.count).to eq 1
       expect(travel_request).to be_approved
+    end
+
+    it "requires a travel category for a department head to fully approve" do
+      staff_profile = FactoryBot.create :staff_profile, :with_department, supervisor: creator
+      staff_profile.department.head = creator
+      staff_profile.department.save
+      travel_request = FactoryBot.create(:travel_request, creator: staff_profile)
+      notes = { notes: [{ content: "Important message" }] }
+      put :decide, params: { id: travel_request.to_param, travel_request: notes, approve: "" }, session: valid_session
+      expect(assigns(:request_change_set).errors.messages).to eq(travel_category: ["is required to approve."])
+      expect(travel_request.notes.count).to eq 0
+      expect(travel_request).not_to be_approved
     end
 
     it "does not allow the creator to approve" do

--- a/spec/features/decide_travel_request_spec.rb
+++ b/spec/features/decide_travel_request_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "New Leave Request", type: :feature, js: true do
+  let(:user) { FactoryBot.create :user }
+  let(:department_head) do
+    profile = FactoryBot.create :staff_profile, user: user, given_name: "Sally", surname: "Smith"
+    FactoryBot.create :department, head: profile
+    profile
+  end
+  let(:staff_profile) do
+    FactoryBot.create :staff_profile, department: department_head.department, given_name: "John", surname: "Doe",
+                                      supervisor: department_head
+  end
+
+  let(:travel_request) { FactoryBot.create :travel_request, creator: staff_profile }
+
+  before do
+    sign_in user
+  end
+
+  scenario "I can approve a travel request" do
+    visit "/travel_requests/#{travel_request.id}/review"
+
+    fill_in "travel_request_notes_content", with: "Make Changes"
+
+    click_on "Request Changes"
+    expect(page).to have_content "Travel request was successfully updated."
+    expect(page).to have_content "Changes requested"
+
+    # the user fixes the issues in the background
+    travel_request.reload
+    travel_request.fix_requested_changes!(agent: staff_profile)
+
+    # Approve the request
+    visit "/travel_requests/#{travel_request.id}/review"
+
+    fill_in "travel_request_notes_content", with: "Elephants Love Balloons"
+    click_on "Approve"
+    expect(page).to have_content "Travel category is required to approve."
+    find("#travel_request_travel_category option[value='business']").select_option
+    click_on "Approve"
+    expect(page).to have_content "Travel request was successfully updated."
+    expect(page).to have_content "Approved"
+    expect(page).to have_content "Elephants Love Balloons"
+  end
+end


### PR DESCRIPTION
fixes #583

This was a little more complicated since I wanted to be certain they did not lose their note in the process of the validation error.  Now the data is being bounced to the server and back vs a javascript requirement.