### PR TITLE
Adds browser support information on help page

### DIFF
--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -81,6 +81,7 @@
       <card size="full-width">
         <card-content>
           <heading level="h2" size="h3" id="report-problem">Report a Problem</heading>
+          <alert class="tip-card">Please use the latest version of Chrome, Edge, or Firefox to use this application. Internet Explorer is not supported.</alert>
           <text-style>If you are looking for technical support or would like to provide feedback on this application, please contact <%= mail_to "lsupport@princeton.edu", "lsupport@princeton.edu" %>.</text-style>
           <text-style><strong>Note</strong>: When reporting issues, please include screenshots, if possible.</text-style>
         </card-content>


### PR DESCRIPTION
<img width="1068" alt="Screen Shot 2020-03-02 at 11 41 08 AM" src="https://user-images.githubusercontent.com/8161144/75697419-0a31f380-5c7b-11ea-9c6a-9f06243b9df6.png">
