### PR TITLE
Adding default order to notes

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -2,4 +2,6 @@
 class Note < ApplicationRecord
   belongs_to :request
   belongs_to :creator, class_name: "StaffProfile", foreign_key: "creator_id"
+
+  default_scope { order("created_at ASC") }
 end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -8,4 +8,17 @@ RSpec.describe Note, type: :model do
     it { is_expected.to respond_to :content }
     it { is_expected.to respond_to :request }
   end
+  describe "#all" do
+    it "is ordered by created_by" do
+      absence_request = FactoryBot.create :absence_request
+      note1 = FactoryBot.create :note, request: absence_request
+      travel_request = FactoryBot.create :travel_request
+      note2 = FactoryBot.create :note, request: travel_request
+      note3 = FactoryBot.create :note, request: travel_request
+      note4 = FactoryBot.create :note, request: absence_request
+      expect(Note.all).to eq([note1, note2, note3, note4])
+      expect(absence_request.notes).to eq([note1, note4])
+      expect(travel_request.notes).to eq([note2, note3])
+    end
+  end
 end


### PR DESCRIPTION
This will force the first note to always be the delegate note if it is present