### PR TITLE
Removing our hand creation of json

### DIFF
--- a/app/change_sets/travel_request_change_set.rb
+++ b/app/change_sets/travel_request_change_set.rb
@@ -83,12 +83,12 @@ class TravelRequestChangeSet < RequestChangeSet
   def recurring_event_list
     if @previous_count != RecurringEvent.count
       @values = RecurringEvent.all.map do |event|
-        "{ id: '#{event.id}', label: '#{event.name}' }"
-      end.join(",")
+        { id: event.id, label: event.name }
+      end
       @previous_count = RecurringEvent.count
     end
 
-    "[#{@values}]"
+    @values.to_json
   end
 
   def supervisor

--- a/spec/change_sets/travel_request_change_set_spec.rb
+++ b/spec/change_sets/travel_request_change_set_spec.rb
@@ -98,11 +98,11 @@ RSpec.describe TravelRequestChangeSet, type: :model do
   describe "#recurring_event_list" do
     it "responds with recurring events and will calculate new ones only if needed" do
       event1 = FactoryBot.create :recurring_event, name: "abc"
-      expect(travel_request.recurring_event_list).to eq("[{ id: '#{event1.id}', label: 'abc' }]")
+      expect(travel_request.recurring_event_list).to eq("[{\"id\":#{event1.id},\"label\":\"abc\"}]")
       event2 = FactoryBot.create :recurring_event, name: "two"
-      expect(travel_request.recurring_event_list).to eq("[{ id: '#{event1.id}', label: 'abc' },{ id: '#{event2.id}', label: 'two' }]")
+      expect(travel_request.recurring_event_list).to eq("[{\"id\":#{event1.id},\"label\":\"abc\"},{\"id\":#{event2.id},\"label\":\"two\"}]")
       values_before = travel_request.instance_variable_get(:@values)
-      expect(travel_request.recurring_event_list).to eq("[{ id: '#{event1.id}', label: 'abc' },{ id: '#{event2.id}', label: 'two' }]")
+      expect(travel_request.recurring_event_list).to eq("[{\"id\":#{event1.id},\"label\":\"abc\"},{\"id\":#{event2.id},\"label\":\"two\"}]")
       values_after = travel_request.instance_variable_get(:@values)
       expect(values_after).to be(values_before)
     end

--- a/spec/features/new_travel_request_spec.rb
+++ b/spec/features/new_travel_request_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "New Travel Request", type: :feature, js: true do
     visit "/travel_requests/new"
 
     find("#travel_request_participation option[value='other']").select_option
-    fill_in "displayInput", with: "Super Event"
+    fill_in "displayInput", with: "Super Event's Are Us"
 
     fill_in "travel_request_event_requests_attributes_0_event_dates", with: "10/1/2019 - 10/3/2019"
     fill_in "travel_request_travel_dates", with: "10/1/2019 - 10/3/2019"
@@ -40,7 +40,7 @@ RSpec.feature "New Travel Request", type: :feature, js: true do
     Percy.snapshot(page, name: "Travel Request - New", widths: [375, 768, 1440])
     click_on "Submit Request"
 
-    expect(page).to have_content "Super Event 2019, A Place To Be (10/01/2019 to 10/03/2019)"
+    expect(page).to have_content "Super Event's Are Us 2019, A Place To Be (10/01/2019 to 10/03/2019)"
     expect(page).to have_content "Airfare 2 20.00 40.00\nLodging (per night) 3 30.00 90.00\nTotal: 130.00"
     expect(page).to have_content "Pending"
     expect(page).to have_content "Elephants Love Balloons"
@@ -56,7 +56,7 @@ RSpec.feature "New Travel Request", type: :feature, js: true do
     expect(page).to have_content "Snakes Love Balloons too!"
 
     click_on "Cancel"
-    expect(page).to have_content "Super Event 2019, A Place To Be (10/01/2019 to 10/03/2019)"
+    expect(page).to have_content "Super Event's Are Us 2019, A Place To Be (10/01/2019 to 10/03/2019)"
     expect(page).to have_content "Airfare 2 20.00 40.00\nLodging (per night) 3 30.00 90.00\nTotal: 130.00"
     expect(page).to have_content "Canceled"
     expect(page).not_to have_selector(:link_or_button, "Edit")


### PR DESCRIPTION
Allow ruby to create appropriate json even when an apostrophe is present