### PR TITLE
i775: rake task for removing delegate relationships

### DIFF
--- a/docs/leaving_princeton.md
+++ b/docs/leaving_princeton.md
@@ -1,0 +1,10 @@
+# Leaving Princeton
+
+When an admin assistant leaves PUL, follow these steps:
+
+1. Remove them from `config/departments.yml`
+1. On a production server:
+```
+cd /opt/approvals/current
+bundle exec rake approvals:stop_being_a_delegate\[netid\]
+```

--- a/lib/tasks/approvals.rake
+++ b/lib/tasks/approvals.rake
@@ -92,6 +92,17 @@ namespace :approvals do
     puts "created #{delegate} can not act on behalf of #{delegator}"
   end
 
+  desc "Make sure this user is no longer anybody's delegate"
+  task :stop_being_a_delegate, [:delegate_uid] => [:environment] do |_t, args|
+    delegate_uid = args[:delegate_uid]
+    delegate = StaffProfile.find_by(uid: delegate_uid)
+    abort "Invalid delegate uid (netid) #{delegate_uid}" if delegate.blank?
+
+    results = Delegate.where(delegate_id: delegate.id).destroy_all
+    puts "#{delegate_uid} was previously a delegate for #{results.count} other users \n" \
+         "#{delegate_uid} is no longer serving as a delegate for anyone."
+  end
+
   def make_requests(staff_profile:)
     1.upto(Random.rand(5...20)) do
       status = ["pending", "approved", "denied", "changes_requested", "canceled"].sample


### PR DESCRIPTION
closes #775 

When run on staging:

```
$ bundle exec rake approvals:stop_being_a_delegate[bszwast]
bszwast was previously a delegate for 88 other users 
bszwast is no longer serving as a delegate for anyone.
```

@kevinreiss does this seem correct?