### PR TITLE
Adjust scheduled staff list processing time

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 env :PATH, ENV["PATH"]
 
-every :day, at: "12:20am", roles: [:app] do
+# Run at 6:05 am EST or 7:05 EDT (after the 5am staff report is generated)
+every :day, at: "11:05 am", roles: [:app] do
   rake "approvals:process_reports", output: "log/cron.log"
 end


### PR DESCRIPTION
Adjust scheduled staff list to occur after the new staff list is posted at 5 a.m. eastern.