### PR TITLE
Remove "Discretionary" as a travel cat option

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -65,8 +65,7 @@ class Request < ApplicationRecord
 
   enum travel_category: {
     business: "business",
-    professional_development: "professional_development",
-    discretionary: "discretionary"
+    professional_development: "professional_development"
   }
 
   enum absence_type: {

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -69,7 +69,7 @@
           <text-style>In order to decline a travel request, you must include a reason in the note field.</text-style>
           <text-style>At this point you may also "Request Changes" by adding notes and clicking on the "Request Changes" button. For example, anticipated expenses that will not be covered by the University should be requested to be deleted.</text-style>
           <text-style>You will receive notifications when the status of the request changes.</text-style>
-          <text-style>The department head will have the ability to choose the travel category (business, professional development, or discretionary).</text-style>
+          <text-style>The department head will have the ability to choose the travel category (business or professional development).</text-style>
         </card-content>
       </card>
       <card size="full-width">

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe RequestsController, type: :controller do
 
     it "accepts limit by status and request type" do
       my_business_travel = FactoryBot.create(:travel_request, creator: staff_profile, action: "approve", travel_category: "business")
-      FactoryBot.create(:travel_request, creator: staff_profile, action: "approve", travel_category: "discretionary")
+      FactoryBot.create(:travel_request, creator: staff_profile, action: "approve", travel_category: "professional_development")
       get :my_requests, params: { filters: { request_type: "business", status: "approved" } }, session: valid_session
       expect(assigns(:requests).map(&:id)).to contain_exactly(my_business_travel.id)
     end

--- a/spec/decorators/report_list_decorator_spec.rb
+++ b/spec/decorators/report_list_decorator_spec.rb
@@ -140,14 +140,12 @@ RSpec.describe ReportListDecorator, type: :model do
   describe "#travel_filter_urls" do
     let(:business_filter) { "/reports?filters%5Brequest_type%5D=business#{status_filter}" }
     let(:professional_development_filter) { "/reports?filters%5Brequest_type%5D=professional_development#{status_filter}" }
-    let(:discretionary_filter) { "/reports?filters%5Brequest_type%5D=discretionary#{status_filter}" }
 
     let(:status_filter) { "" }
     let(:filters) do
       {
         "Business" => business_filter,
-        "Professional development" => professional_development_filter,
-        "Discretionary" => discretionary_filter
+        "Professional development" => professional_development_filter
       }
     end
 

--- a/spec/decorators/request_list_decorator_spec.rb
+++ b/spec/decorators/request_list_decorator_spec.rb
@@ -140,14 +140,12 @@ RSpec.describe RequestListDecorator, type: :model do
   describe "#travel_filter_urls" do
     let(:business_filter) { "/my_requests?filters%5Brequest_type%5D=business#{status_filter}" }
     let(:professional_development_filter) { "/my_requests?filters%5Brequest_type%5D=professional_development#{status_filter}" }
-    let(:discretionary_filter) { "/my_requests?filters%5Brequest_type%5D=discretionary#{status_filter}" }
 
     let(:status_filter) { "" }
     let(:filters) do
       {
         "Business" => business_filter,
-        "Professional development" => professional_development_filter,
-        "Discretionary" => discretionary_filter
+        "Professional development" => professional_development_filter
       }
     end
 

--- a/spec/decorators/travel_request_decorator_spec.rb
+++ b/spec/decorators/travel_request_decorator_spec.rb
@@ -40,12 +40,6 @@ RSpec.describe TravelRequestDecorator, type: :model do
         expect(travel_request_decorator.travel_category_icon).to eq "lux-icon-globe"
       end
     end
-    context "when travel_category is discretionary" do
-      let(:travel_request) { FactoryBot.create(:travel_request, travel_category: :discretionary) }
-      it "returns the correct lux icon" do
-        expect(travel_request_decorator.travel_category_icon).to eq "lux-icon-globe"
-      end
-    end
   end
 
   describe "#formatted_start_date" do

--- a/spec/services/approval_requests_list_spec.rb
+++ b/spec/services/approval_requests_list_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe ApprovalRequestList, type: :model do
 
     it "accepts limit by status and request type" do
       my_business_travel = FactoryBot.create(:travel_request, creator: staff_profile, action: "fix_requested_changes", travel_category: "business")
-      FactoryBot.create(:travel_request, creator: staff_profile, action: "fix_requested_changes", travel_category: "discretionary")
+      FactoryBot.create(:travel_request, creator: staff_profile, action: "fix_requested_changes", travel_category: "professional_development")
       list = described_class.list_requests(approver: staff_profile.supervisor, request_filters: { "request_type" => "business", "status" => "pending" }, search_query: nil, order: nil)
       expect(list.map(&:id)).to contain_exactly(my_business_travel.id)
     end

--- a/spec/services/report_requests_list_spec.rb
+++ b/spec/services/report_requests_list_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe ReportRequestList, type: :model do
 
     it "accepts limit by status and request type" do
       my_business_travel = FactoryBot.create(:travel_request, creator: staff_profile, action: "approve", travel_category: "business")
-      FactoryBot.create(:travel_request, creator: staff_profile, action: "approve", travel_category: "discretionary")
+      FactoryBot.create(:travel_request, creator: staff_profile, action: "approve", travel_category: "professional_development")
       list = described_class.list_requests(current_staff_profile: supervisor, request_filters: { "request_type" => "business", "status" => "approved" }, search_query: nil, order: nil)
       expect(list.map(&:id)).to contain_exactly(my_business_travel.id)
     end

--- a/spec/services/requests_list_spec.rb
+++ b/spec/services/requests_list_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe RequestList, type: :model do
 
     it "accepts limit by status and request type" do
       my_business_travel = FactoryBot.create(:travel_request, creator: staff_profile, action: "approve", travel_category: "business")
-      FactoryBot.create(:travel_request, creator: staff_profile, action: "approve", travel_category: "discretionary")
+      FactoryBot.create(:travel_request, creator: staff_profile, action: "approve", travel_category: "professional_development")
       list = described_class.list_requests(creator: staff_profile, request_filters: { "request_type" => "business", "status" => "approved" }, search_query: nil, order: nil)
       expect(list.map(&:id)).to contain_exactly(my_business_travel.id)
     end


### PR DESCRIPTION
~It appears that while this category has been used in test data on staging, it has not been used at all on production. Should we create a migration to drop it as an option from the database? Would that cause more trouble on staging than it's worth?~ (see discussion below)

Closes #872