### PR TITLE
Ensure department admin_assistants reflect current config

### DIFF
--- a/app/services/staff_report_processor.rb
+++ b/app/services/staff_report_processor.rb
@@ -118,6 +118,8 @@ class StaffReportProcessor
       end
 
       def set_admin_assistants(department:, admin_assistants:)
+        # Clear out old admin_assistants based on earlier configs
+        department.admin_assistants = []
         admin_assistants.each do |net_id|
           aa = StaffProfile.find_by(uid: net_id)
           department.admin_assistants << aa if aa.present?

--- a/spec/services/ldap_spec.rb
+++ b/spec/services/ldap_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Ldap, type: :model do
     # this test can not be run on circle (tagged :no_ci to not run on circle ci)
     it "returns json ldap data about the user when connected to the actual ldap (you must be on campus or VPN for this to work)", :no_ci do
       expect(described_class.find_by_netid("cac9")).to eq(address: "Firestone Library$Library Information Technology",
-                                                          department: "Library - Deputy University Library",
+                                                          department: "Library - Office of the Deputy University Librarian",
                                                           netid: "cac9")
     end
 
@@ -19,11 +19,11 @@ RSpec.describe Ldap, type: :model do
 
       it "returns json about the user" do
         allow(entry).to receive(:[]).with(:uid).and_return(["cac9"])
-        allow(entry).to receive(:[]).with(:ou).and_return(["Library - Deputy University Library"])
+        allow(entry).to receive(:[]).with(:ou).and_return(["Library - Office of the Deputy University Librarian"])
         allow(entry).to receive(:[]).with(:puinterofficeaddress).and_return(["Firestone Library$Library Information Technology"])
 
         expect(described_class.find_by_netid("cac9", ldap_connection: connection)).to eq(address: "Firestone Library$Library Information Technology",
-                                                                                         department: "Library - Deputy University Library",
+                                                                                         department: "Library - Office of the Deputy University Librarian",
                                                                                          netid: "cac9")
       end
     end


### PR DESCRIPTION
Closes #880 

After running the staff report on the staging environment:
```ruby
irb(main):001:0> department = Department::find_by(number: 41000)
  Department Load (0.5ms)  SELECT "departments".* FROM "departments" WHERE "departments"."number" = $1 LIMIT $2  [["number", "41000"], ["LIMIT", 1]]
=> #<Department id: 2, name: "Library - Main", head_id: 32, created_at: "2020-01-27 20:39:42.775666000 +0000", upda...
irb(main):002:0> department.admin_assistant_ids
   (1.5ms)  SELECT "staff_profiles"."id" FROM "staff_profiles" INNER JOIN "admin_assistants_departments" ON "staff_profiles"."id" = "admin_assistants_departments"."admin_assistant_id" WHERE "admin_assistants_departments"."department_id" = $1  [["department_id", 2]]
=> [27]
```