### PR TITLE
Update Procfile to use vite, rather than dev

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 # Procfile
 backend: bin/rails s -p 3000
-frontend: bin/webpack-dev-server
+frontend: bin/vite dev


### PR DESCRIPTION
The old Procfile caused `foreman start` to fail