### PR TITLE
Upgrade net-ssh and upstream dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,9 @@ gem "aasm"
 # ldap
 gem "net-ldap"
 
+# net-ssh
+gem "net-ssh", "7.0.0.beta1"
+
 # pagination
 gem "kaminari"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    airbrussh (1.3.3)
+    airbrussh (1.4.1)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
     bcrypt (3.1.18)
@@ -79,7 +79,7 @@ GEM
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.0.1)
-    capistrano (3.11.0)
+    capistrano (3.17.3)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -155,7 +155,7 @@ GEM
     hashie (5.0.0)
     high_voltage (3.1.2)
     honeybadger (5.0.2)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
@@ -202,11 +202,11 @@ GEM
       net-protocol
     net-protocol (0.2.1)
       timeout
-    net-scp (2.0.0)
-      net-ssh (>= 2.6.5, < 6.0.0)
+    net-scp (4.0.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
     net-smtp (0.3.3)
       net-protocol
-    net-ssh (5.2.0)
+    net-ssh (7.0.0.beta1)
     nio4r (2.5.9)
     nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
@@ -369,7 +369,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sshkit (1.20.0)
+    sshkit (1.21.5)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     thor (1.2.1)
@@ -434,6 +434,7 @@ DEPENDENCIES
   kaminari
   listen (>= 3.0.5, < 3.2)
   net-ldap
+  net-ssh (= 7.0.0.beta1)
   omniauth-cas
   omniauth-rails_csrf_protection (~> 0.1)
   percy-capybara (~> 4.0.0)


### PR DESCRIPTION
Needed for Jammy upgrade

```
Bundler could not find compatible versions for gem "net-ssh":
  In Gemfile:
    net-ssh (= 7.0.0.beta1)

    capistrano-yarn (~> 2.0) was resolved to 2.0.2, which depends on
      capistrano (~> 3.0) was resolved to 3.11.0, which depends on
        sshkit (>= 1.9.0) was resolved to 1.20.0, which depends on
          net-scp (>= 1.1.2) was resolved to 2.0.0, which depends on
            net-ssh (>= 2.6.5, < 6.0.0)
➜  approvals git:(update_net_ssh) ✗ bundle update net-ssh capistrano-yarn capistrano sshkit net-scp
```