### PR TITLE
Update Staff Report Processing Time

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 env :PATH, ENV["PATH"]
 
-# Run at 6:05 am EST or 7:05 EDT (after the 5am staff report is generated)
-every :day, at: "11:05 am", roles: [:app] do
+# Run at 9:05 am EST or 10:05 EDT (after the 8am staff report is generated)
+every :day, at: "02:05 pm", roles: [:app] do
   rake "approvals:process_reports", output: "log/cron.log"
 end


### PR DESCRIPTION
OIT advises they needed to change the report run time to 8 a.m. Updating schedule.