### PR TITLE
Update reform and reform-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,8 +28,8 @@ gem "ed25519"
 gem "bootsnap", ">= 1.1.0", require: false
 
 gem "faker"
-gem "reform", "~> 2.2.4"
-gem "reform-rails"
+gem "reform", "2.3.1"
+gem "reform-rails", "0.2.6"
 gem "whenever", require: false
 
 # Single sign on

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,12 +278,13 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    reform (2.2.4)
-      disposable (>= 0.4.1)
+    reform (2.3.1)
+      disposable (>= 0.4.2, < 0.5.0)
       representable (>= 2.4.0, < 3.1.0)
-    reform-rails (0.1.7)
-      activemodel (>= 3.2)
-      reform (>= 2.2.0)
+      uber (< 0.2.0)
+    reform-rails (0.2.6)
+      activemodel (>= 5.0)
+      reform (>= 2.3.1, < 3.0.0)
     regexp_parser (2.8.2)
     representable (3.0.4)
       declarative (< 0.1.0)
@@ -425,8 +426,8 @@ DEPENDENCIES
   rails (~> 6.0)
   rails-controller-testing
   rails_real_favicon
-  reform (~> 2.2.4)
-  reform-rails
+  reform (= 2.3.1)
+  reform-rails (= 0.2.6)
   rspec-rails (~> 4.0.1)
   rspec_junit_formatter
   selenium-webdriver

--- a/app/controllers/travel_requests_controller.rb
+++ b/app/controllers/travel_requests_controller.rb
@@ -7,12 +7,12 @@ class TravelRequestsController < CommonRequestController
   # PATCH/PUT
   def decide
     if params[:change_request]
-      request_change_set.errors.add(:notes, "are required to specify requested changes.") if processed_params[:notes].blank?
+      pending_errors.push({ attribute: :notes, type: "are required to specify requested changes." }) if processed_params[:notes].blank?
       run_action(action: :change_request, change_method: :supervisor_can_change?)
     elsif params[:change_event]
       update_event
     else
-      request_change_set.errors.add(:travel_category, "is required to approve.") if params[:approve] && processed_params[:travel_category].blank? && current_staff_profile.department_head?
+      pending_errors.push({ attribute: :travel_category, type: "is required to approve." }) if params[:approve] && processed_params[:travel_category].blank? && current_staff_profile.department_head?
       super
     end
   end
@@ -111,7 +111,7 @@ class TravelRequestsController < CommonRequestController
       hash[:start_date] = dates[:start]
       hash[:end_date] = dates[:end]
     rescue ArgumentError
-      request_change_set.errors.add(field, "must be in a valid format (mm/dd/yyyy - mm/dd/yyyy)")
+      pending_errors.push({ attribute: field, type: "must be in a valid format (mm/dd/yyyy - mm/dd/yyyy)" })
     end
 
     def processed_params

--- a/spec/change_sets/absence_request_change_set_spec.rb
+++ b/spec/change_sets/absence_request_change_set_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe AbsenceRequestChangeSet, type: :model do
         }
       end
 
-      it "is valid" do
+      it "is not valid" do
         absence_request.validate({})
         expect(absence_request.errors.messages).to eq(errors)
       end

--- a/spec/controllers/absence_requests_controller_spec.rb
+++ b/spec/controllers/absence_requests_controller_spec.rb
@@ -367,7 +367,8 @@ RSpec.describe AbsenceRequestsController, type: :controller do
         post :create, params: { absence_request: invalid_attributes, format: :json }, session: valid_session
         expect(response).not_to be_successful
         expect(response.media_type).to eq("application/json")
-        expect(response.body).to eq('{"absence_type":["is not included in the list"],"end_date":["can\'t be blank"],"hours_requested":["can\'t be blank"],"start_date":["can\'t be blank"]}')
+        expect(JSON.parse(response.body)).to eq({ "absence_type" => ["is not included in the list"], "end_date" => ["can\'t be blank"], "hours_requested" => ["can\'t be blank"],
+                                                  "start_date" => ["can\'t be blank"] })
       end
     end
 


### PR DESCRIPTION
The main issue is that the reform rails #validate method now delegates to the ActiveModel implementation, which clears out any errors that had been added manually previous to calling #validate.  To allow controllers to still add errors manually, this commit stores them in an array called pending_errors, so they can be applied after #validate is called.

Helps with #851 