### PR TITLE
Use lux-styleguidist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,24 @@ jobs:
             - approvals-yarn-v1-{{ checksum "yarn.lock" }}
             - approvals-yarn-v1-
 
+      # The following steps should only be needed until we publish the new lux-styleguidist package
+      ## Start temporary steps
+      - run:
+          name: Clone lux-styleguidist repository
+          command: git clone https://github.com/pulibrary/lux-styleguidist.git ~/lux-styleguidist
+
+      - run:
+          name: Add yalc globally
+          command: yarn global add yalc
+
+      - run:
+          name: Build lux-styleguidist
+          command: cd ~/lux-styleguidist && npm install && npm run build && yarn exec yalc publish
+
+      - run:
+          name: Add lux-styleguidist to approvals using yalc
+          command: yarn exec yalc add lux-design-system
+      ## End temporary steps
       - run:
           name: Yarn Install
           command: yarn install --cache-folder ~/.cache/yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,25 +76,6 @@ jobs:
           keys:
             - approvals-yarn-v1-{{ checksum "yarn.lock" }}
             - approvals-yarn-v1-
-
-      # The following steps should only be needed until we publish the new lux-styleguidist package
-      ## Start temporary steps
-      - run:
-          name: Clone lux-styleguidist repository
-          command: git clone https://github.com/pulibrary/lux-styleguidist.git ~/lux-styleguidist
-
-      - run:
-          name: Add yalc globally
-          command: yarn global add yalc
-
-      - run:
-          name: Build lux-styleguidist
-          command: cd ~/lux-styleguidist && npm install && npm run build && yarn exec yalc publish
-
-      - run:
-          name: Add lux-styleguidist to approvals using yalc
-          command: yarn exec yalc add lux-design-system
-      ## End temporary steps
       - run:
           name: Yarn Install
           command: yarn install --cache-folder ~/.cache/yarn

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -9,7 +9,7 @@ globals:
   Atomics: readonly
   SharedArrayBuffer: readonly
 parserOptions:
-  ecmaVersion: 2018
+  ecmaVersion: 2020
   sourceType: module
 parser: vue-eslint-parser
 plugins:

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ node_modules
 # https://vitejs.dev/guide/env-and-mode.html#env-files
 *.local
 
+.vscode/
+

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -49,17 +49,5 @@
  }
 
  article.full-width {
-   width: 100%;
-   display: flex;
-   align-items: flex-start;
-   flex-flow: row wrap;
-   box-sizing: border-box;
-   margin: 24px 0 24px 0;
-   font-family: franklin-gothic-urw,Helvetica,Arial,sans-serif;
-   line-height: 1.6;
-   background: #fff;
-   box-shadow: 0 0 0 1px rgba(92,106,196,.1);
-   color: #001123;
-   position: relative;
-   margin-bottom: 0;
+   margin: 24px 0 0;
  }

--- a/app/javascript/components/eventDateModal.vue
+++ b/app/javascript/components/eventDateModal.vue
@@ -15,22 +15,22 @@
             </slot>
           </div>
           <div class="modal-footer">
-            <input-button
+            <lux-input-button
               type="button"
               variation="solid"
               size="small"
               @button-clicked="submit"
             >
               Continue
-            </input-button>
-            <input-button
+            </lux-input-button>
+            <lux-input-button
               type="button"
               variation="outline"
               size="small"
               @button-clicked="$emit('closeModal')"
             >
               Go Back
-            </input-button>
+            </lux-input-button>
           </div>
         </div>
       </div>

--- a/app/javascript/components/eventTitleInputWrapper.vue
+++ b/app/javascript/components/eventTitleInputWrapper.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="event-title-container">
-    <input-autocomplete
+    <lux-autocomplete-input
       id="travel_request_event_requests_attributes_0_recurring_event_id"
       required
       name="travel_request[event_requests_attributes][0][recurring_event_id]"

--- a/app/javascript/components/hoursCalculator.vue
+++ b/app/javascript/components/hoursCalculator.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <date-picker
+    <lux-date-picker
       id="absence_request_date"
       name="absence_request[start_date]"
       label="Date range"

--- a/app/javascript/components/hoursCalculator.vue
+++ b/app/javascript/components/hoursCalculator.vue
@@ -34,7 +34,7 @@
       :helper="helperCaption"
       :value="localHoursRequested"
       required
-      @input="updateCaption($event)"
+      @inputvaluechange="updateCaption($event)"
     />
   </div>
 </template>

--- a/app/javascript/components/hoursCalculator.vue
+++ b/app/javascript/components/hoursCalculator.vue
@@ -26,7 +26,7 @@
       :value="localEndDate"
     >
 
-    <input-text
+    <lux-input-text
       id="absence_request_hours_requested"
       name="absence_request[hours_requested]"
       width="expand"

--- a/app/javascript/components/travelEstimateForm.vue
+++ b/app/javascript/components/travelEstimateForm.vue
@@ -110,7 +110,7 @@
             width="expand"
             required
             hide-label
-            @input="updateRecurrence($event, expense)"
+            @inputvaluechange="updateRecurrence($event, expense)"
           />
         </lux-grid-item>
         <lux-grid-item
@@ -127,7 +127,7 @@
             placeholder="$ 0.00"
             required
             hide-label
-            @input="updateAmount($event, expense)"
+            @inputvaluechange="updateAmount($event, expense)"
           />
         </lux-grid-item>
         <lux-grid-item

--- a/app/javascript/components/travelEstimateForm.vue
+++ b/app/javascript/components/travelEstimateForm.vue
@@ -1,60 +1,60 @@
 <template>
-  <grid-container class="expenses">
-    <grid-item
+  <lux-grid-container class="expenses">
+    <lux-grid-item
       columns="lg-12 sm-12"
       class="expense-row-header"
     >
-      <grid-container>
-        <grid-item
+      <lux-grid-container>
+        <lux-grid-item
           vertical="center"
           columns="lg-1 sm-12"
           class="expense-delete"
         >
           <lux-text-style>Delete</lux-text-style>
-        </grid-item>
-        <grid-item
+        </lux-grid-item>
+        <lux-grid-item
           vertical="center"
           columns="lg-2 sm-12"
         >
           <lux-text-style id="expense-type-column">
             Expense Type
           </lux-text-style>
-        </grid-item>
-        <grid-item
+        </lux-grid-item>
+        <lux-grid-item
           vertical="center"
           columns="lg-1 sm-12"
         >
           <lux-text-style>Occurrences</lux-text-style>
-        </grid-item>
-        <grid-item
+        </lux-grid-item>
+        <lux-grid-item
           vertical="center"
           columns="lg-2 sm-12"
         >
           <lux-text-style>Cost per Occurrence</lux-text-style>
-        </grid-item>
-        <grid-item
+        </lux-grid-item>
+        <lux-grid-item
           vertical="center"
           columns="lg-4 sm-12"
         >
           <lux-text-style>Note</lux-text-style>
-        </grid-item>
-        <grid-item
+        </lux-grid-item>
+        <lux-grid-item
           vertical="center"
           columns="lg-2 sm-12"
         >
           <lux-text-style>Total</lux-text-style>
-        </grid-item>
-      </grid-container>
-    </grid-item>
+        </lux-grid-item>
+      </lux-grid-container>
+    </lux-grid-item>
 
-    <grid-item
+    <lux-grid-item
       v-for="expense in expenseData"
       :key="expense.id"
       columns="lg-12 sm-12"
       class="expense-row"
     >
-      <grid-container>
-        <grid-item
+      <lux-grid-container>
+        <lux-grid-item
           vertical="center"
           columns="lg-1 sm-12"
           class="expense-delete"
@@ -79,8 +79,8 @@
             name="travel_request[estimates][][id]"
             :value="expense.id"
           >
-        </grid-item>
-        <grid-item
+        </lux-grid-item>
+        <lux-grid-item
           vertical="center"
           columns="lg-2 sm-12"
         >
@@ -96,8 +96,8 @@
             hide-label
             @change="updateExpenseType($event, expense)"
           />
-        </grid-item>
-        <grid-item
+        </lux-grid-item>
+        <lux-grid-item
           vertical="center"
           columns="lg-1 sm-12"
         >
@@ -112,8 +112,8 @@
             hide-label
             @input="updateRecurrence($event, expense)"
           />
-        </grid-item>
-        <grid-item
+        </lux-grid-item>
+        <lux-grid-item
           vertical="center"
           columns="lg-2 sm-12"
         >
@@ -129,8 +129,8 @@
             hide-label
             @input="updateAmount($event, expense)"
           />
-        </grid-item>
-        <grid-item
+        </lux-grid-item>
+        <lux-grid-item
           vertical="center"
           columns="lg-4 sm-12"
         >
@@ -142,8 +142,8 @@
             width="expand"
             hide-label
           />
-        </grid-item>
-        <grid-item
+        </lux-grid-item>
+        <lux-grid-item
           vertical="center"
           columns="lg-2 sm-12"
           class="expense-total-col"
@@ -157,11 +157,11 @@
             disabled
             hide-label
           />
-        </grid-item>
-      </grid-container>
-    </grid-item>
+        </lux-grid-item>
+      </lux-grid-container>
+    </lux-grid-item>
 
-    <grid-item
+    <lux-grid-item
       columns="lg-11 sm-12"
       class="expense-add"
     >
@@ -179,13 +179,13 @@
           <lux-icon-add />
         </lux-icon-base> Add Expense
       </lux-input-button>
-    </grid-item>
+    </lux-grid-item>
 
-    <grid-item columns="lg-12 sm-12">
+    <lux-grid-item columns="lg-12 sm-12">
       <hr>
-    </grid-item>
+    </lux-grid-item>
 
-    <grid-item
+    <lux-grid-item
       columns="lg-10 sm-12 auto"
       class="expense-total"
       :offset="true"
@@ -193,8 +193,8 @@
       <lux-text-style variation="strong">
         Total:
       </lux-text-style>
-    </grid-item>
-    <grid-item
+    </lux-grid-item>
+    <lux-grid-item
       columns="lg-2 sm-12"
       class="expense-total"
     >
@@ -204,8 +204,8 @@
       >
         ${{ expensesTotal() }}
       </lux-text-style>
-    </grid-item>
-  </grid-container>
+    </lux-grid-item>
+  </lux-grid-container>
 </template>
 
 <script>
@@ -239,10 +239,7 @@ export default {
             });
             this.$nextTick(() => {
                 const index = this.expenseData.length - 1;
-                const input = this.$refs.expense_type[index];
-                if (typeof input.children[1] !== 'undefined'){
-                    input.children[1].focus();
-                }
+                const input = this.$refs?.expense_type?.[index]?.focusSelect();
             });
         },
         deleteExpense(expense) {

--- a/app/javascript/components/travelEstimateForm.vue
+++ b/app/javascript/components/travelEstimateForm.vue
@@ -10,7 +10,7 @@
           columns="lg-1 sm-12"
           class="expense-delete"
         >
-          <text-style>Delete</text-style>
+          <lux-text-style>Delete</lux-text-style>
         </grid-item>
         <grid-item
           vertical="center"
@@ -24,25 +24,25 @@
           vertical="center"
           columns="lg-1 sm-12"
         >
-          <text-style>Occurrences</text-style>
+          <lux-text-style>Occurrences</lux-text-style>
         </grid-item>
         <grid-item
           vertical="center"
           columns="lg-2 sm-12"
         >
-          <text-style>Cost per Occurrence</text-style>
+          <lux-text-style>Cost per Occurrence</lux-text-style>
         </grid-item>
         <grid-item
           vertical="center"
           columns="lg-4 sm-12"
         >
-          <text-style>Note</text-style>
+          <lux-text-style>Note</lux-text-style>
         </grid-item>
         <grid-item
           vertical="center"
           columns="lg-2 sm-12"
         >
-          <text-style>Total</text-style>
+          <lux-text-style>Total</lux-text-style>
         </grid-item>
       </grid-container>
     </grid-item>

--- a/app/javascript/components/travelEstimateForm.vue
+++ b/app/javascript/components/travelEstimateForm.vue
@@ -16,9 +16,9 @@
           vertical="center"
           columns="lg-2 sm-12"
         >
-          <text-style id="expense-type-column">
+          <lux-text-style id="expense-type-column">
             Expense Type
-          </text-style>
+          </lux-text-style>
         </grid-item>
         <grid-item
           vertical="center"
@@ -59,7 +59,7 @@
           columns="lg-1 sm-12"
           class="expense-delete"
         >
-          <input-button
+          <lux-input-button
             class="button-delete-row"
             type="button"
             variation="text"
@@ -73,7 +73,7 @@
             >
               <lux-icon-denied />
             </lux-icon-base>
-          </input-button>
+          </lux-input-button>
           <input
             type="hidden"
             name="travel_request[estimates][][id]"
@@ -84,7 +84,7 @@
           vertical="center"
           columns="lg-2 sm-12"
         >
-          <input-select
+          <lux-input-select
             :id="'travel_request_estimates_cost_type_' + expense.id"
             :ref="'expense_type'"
             label="Expense Type"
@@ -165,7 +165,7 @@
       columns="lg-11 sm-12"
       class="expense-add"
     >
-      <input-button
+      <lux-input-button
         id="add-expense-button"
         type="button"
         variation="text"
@@ -178,7 +178,7 @@
         >
           <lux-icon-add />
         </lux-icon-base> Add Expense
-      </input-button>
+      </lux-input-button>
     </grid-item>
 
     <grid-item columns="lg-12 sm-12">
@@ -190,20 +190,20 @@
       class="expense-total"
       :offset="true"
     >
-      <text-style variation="strong">
+      <lux-text-style variation="strong">
         Total:
-      </text-style>
+      </lux-text-style>
     </grid-item>
     <grid-item
       columns="lg-2 sm-12"
       class="expense-total"
     >
-      <text-style
+      <lux-text-style
         id="expenses-total"
         variation="strong"
       >
         ${{ expensesTotal() }}
-      </text-style>
+      </lux-text-style>
     </grid-item>
   </grid-container>
 </template>

--- a/app/javascript/components/travelEstimateForm.vue
+++ b/app/javascript/components/travelEstimateForm.vue
@@ -101,7 +101,7 @@
           vertical="center"
           columns="lg-1 sm-12"
         >
-          <input-text
+          <lux-input-text
             :id="'travel_request_estimates_recurrence_' + expense.id"
             label="Occurrences"
             name="travel_request[estimates][][recurrence]"
@@ -117,7 +117,7 @@
           vertical="center"
           columns="lg-2 sm-12"
         >
-          <input-text
+          <lux-input-text
             :id="'travel_request_estimates_amount_' + expense.id"
             label="Cost per Occurrence"
             name="travel_request[estimates][][amount]"
@@ -134,7 +134,7 @@
           vertical="center"
           columns="lg-4 sm-12"
         >
-          <input-text
+          <lux-input-text
             :id="'travel_request_estimates_description_' + expense.id"
             label="Note"
             name="travel_request[estimates][][description]"
@@ -148,7 +148,7 @@
           columns="lg-2 sm-12"
           class="expense-total-col"
         >
-          <input-text
+          <lux-input-text
             :id="'travel_request_estimates_total_' + expense.id"
             label="Total"
             name="travel_request[estimates][][total]"

--- a/app/javascript/components/travelEstimateForm.vue
+++ b/app/javascript/components/travelEstimateForm.vue
@@ -239,7 +239,7 @@ export default {
             });
             this.$nextTick(() => {
                 const index = this.expenseData.length - 1;
-                const input = this.$refs?.expense_type?.[index]?.focusSelect();
+                this.$refs?.expense_type?.[index]?.focusSelect();
             });
         },
         deleteExpense(expense) {

--- a/app/javascript/components/travelEstimateForm.vue
+++ b/app/javascript/components/travelEstimateForm.vue
@@ -239,7 +239,7 @@ export default {
             });
             this.$nextTick(() => {
                 const index = this.expenseData.length - 1;
-                const input = this.$refs.expense_type[index].$el;
+                const input = this.$refs.expense_type[index];
                 if (typeof input.children[1] !== 'undefined'){
                     input.children[1].focus();
                 }

--- a/app/javascript/components/travelRequestButton.vue
+++ b/app/javascript/components/travelRequestButton.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
-    <input-button
+    <lux-input-button
       id="submit-travel-request"
       type="button"
       variation="solid"
       @button-clicked="submitTravelRequest($event)"
     >
       Submit Request
-    </input-button>
+    </lux-input-button>
     <event-date-modal
       :show-modal="showModal"
       @closeModal="close"

--- a/app/javascript/components/travelRequestButton.vue
+++ b/app/javascript/components/travelRequestButton.vue
@@ -12,11 +12,11 @@
       :show-modal="showModal"
       @closeModal="close"
     >
-      <div slot="body">
+      <template v-slot:body>
         <p>It looks like you have a date in the event title. Please remove before submitting</p>
         <br>
         <p>Detected: {{ matchedDate() }}</p>
-      </div>
+      </template>
     </event-date-modal>
   </div>
 </template>

--- a/app/javascript/components/travelRequestDatePickers.vue
+++ b/app/javascript/components/travelRequestDatePickers.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <date-picker
+    <lux-date-picker
       id="travel_request_event_requests_attributes_0_event_dates"
       label="Event Dates"
       mode="range"
@@ -11,7 +11,7 @@
       :default-dates="eventDates"
       @updateInput="updateTravelDates($event)"
     />
-    <date-picker
+    <lux-date-picker
       id="travel_request_travel_dates"
       label="Travel Dates"
       mode="range"

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -33,7 +33,7 @@ import Rails from "@rails/ujs";
 const app = createApp({});
 const createMyApp = () => createApp(app);
 
-Rails.start();
+// Rails.start();
 
 document.addEventListener("DOMContentLoaded", () => {
     const elements = document.getElementsByClassName("lux");

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -26,22 +26,25 @@ import travelRequestButton from "../components/travelRequestButton.vue";
 import travelRequestDatePickers from "../components/travelRequestDatePickers.vue";
 import '../../assets/stylesheets/application.scss';
 
+// Create a factory function that will create vue
+// apps, which we can then mount to any element with
+// the class .lux
+const app = createApp({});
+const createMyApp = () => createApp(app)
 
-
-// create the LUX app and mount it to wrappers with class="lux"
 document.addEventListener("DOMContentLoaded", () => {
     const elements = document.getElementsByClassName("lux");
     for (let i = 0; i < elements.length; i++) {
-        const app = createApp({});
-        app.use(lux);
-        app.component('event-date-modal', eventDateModal)
-            .component('event-title-input-wrapper', eventTitleInputWrapper)
-            .component('hours-calculator', hoursCalculator)
-            .component('travel-estimate-form', travelEstimateForm)
-            .component('travel-request-button', travelRequestButton)
-            .component('travel-request-date-pickers', travelRequestDatePickers)
-            console.log(app);
-        app.mount(elements[i]);
+        // Call our factory function, then add all the lux components
+        // and approvals components to it
+        createMyApp().use(lux)
+                     .component('event-date-modal', eventDateModal)
+                     .component('event-title-input-wrapper', eventTitleInputWrapper)
+                     .component('hours-calculator', hoursCalculator)
+                     .component('travel-estimate-form', travelEstimateForm)
+                     .component('travel-request-button', travelRequestButton)
+                     .component('travel-request-date-pickers', travelRequestDatePickers)
+                     .mount(elements[i]);
     }
 });
 

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -31,7 +31,7 @@ import Rails from "@rails/ujs";
 // apps, which we can then mount to any element with
 // the class .lux
 const app = createApp({});
-const createMyApp = () => createApp(app)
+const createMyApp = () => createApp(app);
 
 Rails.start();
 
@@ -41,13 +41,13 @@ document.addEventListener("DOMContentLoaded", () => {
         // Call our factory function, then add all the lux components
         // and approvals components to it
         createMyApp().use(lux)
-                     .component('event-date-modal', eventDateModal)
-                     .component('event-title-input-wrapper', eventTitleInputWrapper)
-                     .component('hours-calculator', hoursCalculator)
-                     .component('travel-estimate-form', travelEstimateForm)
-                     .component('travel-request-button', travelRequestButton)
-                     .component('travel-request-date-pickers', travelRequestDatePickers)
-                     .mount(elements[i]);
+            .component('event-date-modal', eventDateModal)
+            .component('event-title-input-wrapper', eventTitleInputWrapper)
+            .component('hours-calculator', hoursCalculator)
+            .component('travel-estimate-form', travelEstimateForm)
+            .component('travel-request-button', travelRequestButton)
+            .component('travel-request-date-pickers', travelRequestDatePickers)
+            .mount(elements[i]);
     }
 });
 

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -15,8 +15,8 @@
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
 
-import Vue from "vue";
-import system from "lux-design-system";
+import {createApp} from "vue";
+import lux from "lux-design-system";
 import "lux-design-system/dist/style.css";
 import eventDateModal from "../components/eventDateModal.vue";
 import eventTitleInputWrapper from "../components/eventTitleInputWrapper.vue";
@@ -24,27 +24,24 @@ import hoursCalculator from "../components/hoursCalculator.vue";
 import travelEstimateForm from "../components/travelEstimateForm.vue";
 import travelRequestButton from "../components/travelRequestButton.vue";
 import travelRequestDatePickers from "../components/travelRequestDatePickers.vue";
-import Rails from '@rails/ujs';
 import '../../assets/stylesheets/application.scss';
 
-Vue.use(system);
+
 
 // create the LUX app and mount it to wrappers with class="lux"
 document.addEventListener("DOMContentLoaded", () => {
     const elements = document.getElementsByClassName("lux");
     for (let i = 0; i < elements.length; i++) {
-        new Vue({
-            el: elements[i],
-            components: {
-                'event-date-modal': eventDateModal,
-                'event-title-input-wrapper': eventTitleInputWrapper,
-                'hours-calculator': hoursCalculator,
-                'travel-estimate-form': travelEstimateForm,
-                'travel-request-button': travelRequestButton,
-                'travel-request-date-pickers': travelRequestDatePickers,
-            }
-        });
+        const app = createApp({});
+        app.use(lux);
+        app.component('event-date-modal', eventDateModal)
+            .component('event-title-input-wrapper', eventTitleInputWrapper)
+            .component('hours-calculator', hoursCalculator)
+            .component('travel-estimate-form', travelEstimateForm)
+            .component('travel-request-button', travelRequestButton)
+            .component('travel-request-date-pickers', travelRequestDatePickers)
+            console.log(app);
+        app.mount(elements[i]);
     }
 });
 
-Rails.start();

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -25,6 +25,12 @@ import travelEstimateForm from "../components/travelEstimateForm.vue";
 import travelRequestButton from "../components/travelRequestButton.vue";
 import travelRequestDatePickers from "../components/travelRequestDatePickers.vue";
 import '../../assets/stylesheets/application.scss';
+
+// We import Rails, because without it, the vite dev
+// server does not seem to have access to it.  However,
+// we don't call Rails.start(), since Rails seems to handle
+// that by itself.
+// eslint-disable-next-line no-unused-vars
 import Rails from "@rails/ujs";
 
 // Create a factory function that will create vue

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -25,12 +25,15 @@ import travelEstimateForm from "../components/travelEstimateForm.vue";
 import travelRequestButton from "../components/travelRequestButton.vue";
 import travelRequestDatePickers from "../components/travelRequestDatePickers.vue";
 import '../../assets/stylesheets/application.scss';
+import Rails from "@rails/ujs";
 
 // Create a factory function that will create vue
 // apps, which we can then mount to any element with
 // the class .lux
 const app = createApp({});
 const createMyApp = () => createApp(app)
+
+Rails.start();
 
 document.addEventListener("DOMContentLoaded", () => {
     const elements = document.getElementsByClassName("lux");

--- a/app/javascript/test/hoursCalculator.spec.js
+++ b/app/javascript/test/hoursCalculator.spec.js
@@ -10,7 +10,13 @@ describe("HoursCalculator.vue", () => {
                 hoursPerDay: 8,
                 holidays: ['2019-12-25','2019-12-26','2019-09-11','2020-12-25']
             },
-            stubs: ["lux-input-text", "date-picker", "grid-item"]
+            global: {
+                stubs: {
+                    "lux-input-text": true,
+                    "lux-date-picker": true,
+                    "lux-grid-item": true
+                }
+            }
         });
     });
 

--- a/app/javascript/test/hoursCalculator.spec.js
+++ b/app/javascript/test/hoursCalculator.spec.js
@@ -10,7 +10,7 @@ describe("HoursCalculator.vue", () => {
                 hoursPerDay: 8,
                 holidays: ['2019-12-25','2019-12-26','2019-09-11','2020-12-25']
             },
-            stubs: ["input-text", "date-picker", "grid-item"]
+            stubs: ["lux-input-text", "date-picker", "grid-item"]
         });
     });
 

--- a/app/javascript/test/hoursCalculator.spec.js
+++ b/app/javascript/test/hoursCalculator.spec.js
@@ -1,13 +1,11 @@
-import { createLocalVue, mount } from "@vue/test-utils";
+import { mount } from "@vue/test-utils";
 import HoursCalculator from "../components/hoursCalculator.vue";
 
-const localVue = createLocalVue();
 let wrapper;
 describe("HoursCalculator.vue", () => {
     beforeEach(() => {
 
         wrapper = mount(HoursCalculator, {
-            localVue,
             propsData: {
                 hoursPerDay: 8,
                 holidays: ['2019-12-25','2019-12-26','2019-09-11','2020-12-25']

--- a/app/javascript/test/setup.js
+++ b/app/javascript/test/setup.js
@@ -1,3 +1,0 @@
-import Vue from 'vue';
-
-Vue.config.productionTip = false;

--- a/app/javascript/test/travelEstimateForm.spec.js
+++ b/app/javascript/test/travelEstimateForm.spec.js
@@ -1,5 +1,6 @@
 import { mount } from "@vue/test-utils";
 import TravelEstimateForm from "../components/travelEstimateForm.vue";
+import {LuxInputSelect, LuxGridContainer, LuxGridItem} from "lux-design-system";
 
 let wrapper;
 describe("travelEstimateForm.vue", () => {
@@ -22,18 +23,23 @@ describe("travelEstimateForm.vue", () => {
                     {label: 'other transit', value: 'transit_other'},
                     {label: 'train', value: 'train'}
                 ]
-            },
-            stubs: [
-                "lux-input-text",
-                "input-select",
-                "input-button",
-                "lux-icon-denied",
-                "lux-icon-add",
-                "lux-icon-base",
-                "grid-container",
-                "grid-item",
-                "text-style",
-            ]
+            }, global: {
+                stubs: {
+                    "lux-input-button": true,
+                    "lux-icon-denied": true,
+                    "lux-icon-add": true,
+                    "lux-icon-base": true,
+                    "lux-grid-container": true,
+                    "lux-grid-item": true,
+                    "lux-text-style": true,
+                    "lux-input-text": true
+                },
+                components: {
+                    "lux-input-select": LuxInputSelect,
+                    "lux-grid-container": LuxGridContainer,
+                    "lux-grid-item": LuxGridItem,
+                }
+            }
         });
     });
 

--- a/app/javascript/test/travelEstimateForm.spec.js
+++ b/app/javascript/test/travelEstimateForm.spec.js
@@ -24,7 +24,7 @@ describe("travelEstimateForm.vue", () => {
                 ]
             },
             stubs: [
-                "input-text",
+                "lux-input-text",
                 "input-select",
                 "input-button",
                 "lux-icon-denied",

--- a/app/javascript/test/travelEstimateForm.spec.js
+++ b/app/javascript/test/travelEstimateForm.spec.js
@@ -1,13 +1,11 @@
-import { createLocalVue, mount } from "@vue/test-utils";
+import { mount } from "@vue/test-utils";
 import TravelEstimateForm from "../components/travelEstimateForm.vue";
 
-const localVue = createLocalVue();
 let wrapper;
 describe("travelEstimateForm.vue", () => {
     beforeEach(() => {
 
         wrapper = mount(TravelEstimateForm, {
-            localVue,
             propsData: {
                 expenses: [
                     {"id":1,"cost_type":"registration","amount":"50.0","recurrence":2,"description":"","other_id":"id_1"},

--- a/app/javascript/test/travelEstimateForm.spec.js
+++ b/app/javascript/test/travelEstimateForm.spec.js
@@ -1,13 +1,12 @@
 import { mount } from "@vue/test-utils";
 import TravelEstimateForm from "../components/travelEstimateForm.vue";
-import {LuxInputSelect, LuxGridContainer, LuxGridItem} from "lux-design-system";
 
 let wrapper;
 describe("travelEstimateForm.vue", () => {
     beforeEach(() => {
 
         wrapper = mount(TravelEstimateForm, {
-            propsData: {
+            props: {
                 expenses: [
                     {"id":1,"cost_type":"registration","amount":"50.0","recurrence":2,"description":"","other_id":"id_1"},
                     {"id":2,"cost_type":"meals","amount":"193.0","recurrence":1,"description":"Foo!","other_id":"id_2"}
@@ -32,13 +31,9 @@ describe("travelEstimateForm.vue", () => {
                     "lux-grid-container": true,
                     "lux-grid-item": true,
                     "lux-text-style": true,
-                    "lux-input-text": true
+                    "lux-input-text": true,
+                    "lux-input-select": true
                 },
-                components: {
-                    "lux-input-select": LuxInputSelect,
-                    "lux-grid-container": LuxGridContainer,
-                    "lux-grid-item": LuxGridItem,
-                }
             }
         });
     });

--- a/app/views/absence_requests/_balances.html.erb
+++ b/app/views/absence_requests/_balances.html.erb
@@ -1,21 +1,21 @@
-  <card size="full-width" class="absence">
-    <card-content>
-      <heading level="h2" size="h5"><%= balance_title %></heading>
-      <heading level="h3" size="h4">
+  <lux-card size="full-width" class="absence">
+    <lux-card-content>
+      <lux-heading level="h2" size="h5"><%= balance_title %></lux-heading>
+      <lux-heading level="h3" size="h4">
         <lux-icon-base icon-name="vacation"><lux-icon-vacation></lux-icon-vacation></lux-icon-base>
         Vacation
-      </heading>
-      <text-style><%= vacation_balance&.round(2) %>  Hours</text-style>
-      <heading level="h3" size="h4">
+      </lux-heading>
+      <lux-text-style><%= vacation_balance&.round(2) %>  Hours</lux-text-style>
+      <lux-heading level="h3" size="h4">
         <lux-icon-base icon-name="relax"><lux-icon-relax></lux-icon-relax></lux-icon-base>
         Personal
-      </heading>
-      <text-style><%= personal_balance&.round(2) %> Hours</text-style>
-      <heading level="h3" size="h4">
+      </lux-heading>
+      <lux-text-style><%= personal_balance&.round(2) %> Hours</lux-text-style>
+      <lux-heading level="h3" size="h4">
       <lux-icon-base icon-name="hospital">
         <lux-icon-hospital></lux-icon-hospital></lux-icon-base>
         Sick
-      </heading>
-      <text-style><%= sick_balance&.round(2) %> Hours</text-style>
-    </card-content>
-  </card>
+      </lux-heading>
+      <lux-text-style><%= sick_balance&.round(2) %> Hours</lux-text-style>
+    </lux-card-content>
+  </lux-card>

--- a/app/views/absence_requests/_errors.html.erb
+++ b/app/views/absence_requests/_errors.html.erb
@@ -1,5 +1,5 @@
 <lux-grid-item columns="lg-12">
-  <alert status="error">
+  <lux-alert status="error">
     <h2><%= pluralize(request_change_set.errors.count, "error") %> prohibited this request from being saved:</h2>
 
     <ul>
@@ -7,5 +7,5 @@
       <li><%= message %></li>
     <% end %>
     </ul>
-  </alert>
+  </lux-alert>
 </lux-grid-item>

--- a/app/views/absence_requests/_errors.html.erb
+++ b/app/views/absence_requests/_errors.html.erb
@@ -1,4 +1,4 @@
-<grid-item columns="lg-12">
+<lux-grid-item columns="lg-12">
   <alert status="error">
     <h2><%= pluralize(request_change_set.errors.count, "error") %> prohibited this request from being saved:</h2>
 
@@ -8,4 +8,4 @@
     <% end %>
     </ul>
   </alert>
-</grid-item>
+</lux-grid-item>

--- a/app/views/absence_requests/_form.html.erb
+++ b/app/views/absence_requests/_form.html.erb
@@ -1,18 +1,18 @@
   <%= form_with(model: request_change_set.model, local: true) do |form| %>
-    <grid-container>
+    <lux-grid-container>
       <% if request_change_set.errors.any? %>
         <%=render 'errors', request_change_set: request_change_set%>
       <% end %>
 
 
-      <grid-item columns="lg-3 sm-12">
-        <input-select label="Absence type" name="absence_request[absence_type]"
+      <lux-grid-item columns="lg-3 sm-12">
+        <lux-input-select label="Absence type" name="absence_request[absence_type]"
                       id="absence_request_absence_type"
                       width="expand"
                       value="<%= request_change_set.absence_type %>"
                       :options="<%= request_change_set.absence_type_options.to_json %>"
                       required=true
-        ></input-select>
+        ></lux-input-select>
 
         <hours-calculator start-date="<%= request_change_set.start_date_js %>"
                           end-date="<%= request_change_set.end_date_js %>"
@@ -24,28 +24,28 @@
                           :holidays="<%=request_change_set.holidays %>"
                           hours-per-day=<%= request_change_set.hours_per_day(current_staff_profile)%>>
         </hours-calculator>
-      </grid-item>
+      </lux-grid-item>
 
-      <grid-item columns="lg-8 sm-12">
+      <lux-grid-item columns="lg-8 sm-12">
           <%= render 'balances', balance_title: request_change_set.balance_title,
                             vacation_balance:  request_change_set.vacation_balance,
                             personal_balance: request_change_set.personal_balance,
                             sick_balance: request_change_set.sick_balance  %>
 
-      </grid-item>
+      </lux-grid-item>
 
-      <!--<grid-item columns="lg-12 sm-12">
+      <!--<lux-grid-item columns="lg-12 sm-12">
         <date-picker id="absence_request_end_date" name="absence_request[end_date]" label="End Date" mode="single"></date-picker>
-      </grid-item>-->
+      </lux-grid-item>-->
 
-      <grid-item columns="lg-8 sm-12">
+      <lux-grid-item columns="lg-8 sm-12">
         <lux-input-text id="absence_request_notes_content" name="absence_request[notes][content]" label="Comments" type="textarea"
                     width="expand"></lux-input-text>
-      </grid-item>
+      </lux-grid-item>
 
-      <grid-item columns="lg-12 sm-12">
+      <lux-grid-item columns="lg-12 sm-12">
       <lux-text-style variation="emphasis">This request will be submitted to: <%= request_change_set.supervisor %></lux-text-style>
-        <input-button type="submit" variation="solid">Submit Request</input-button>
-      </grid-item>
-    </grid-container>
+        <lux-input-button type="submit" variation="solid">Submit Request</lux-input-button>
+      </lux-grid-item>
+    </lux-grid-container>
   <% end %>

--- a/app/views/absence_requests/_form.html.erb
+++ b/app/views/absence_requests/_form.html.erb
@@ -44,7 +44,7 @@
       </grid-item>
 
       <grid-item columns="lg-12 sm-12">
-      <text-style variation="emphasis">This request will be submitted to: <%= request_change_set.supervisor %></text-style>
+      <lux-text-style variation="emphasis">This request will be submitted to: <%= request_change_set.supervisor %></lux-text-style>
         <input-button type="submit" variation="solid">Submit Request</input-button>
       </grid-item>
     </grid-container>

--- a/app/views/absence_requests/_form.html.erb
+++ b/app/views/absence_requests/_form.html.erb
@@ -39,8 +39,8 @@
       </grid-item>-->
 
       <grid-item columns="lg-8 sm-12">
-        <input-text id="absence_request_notes_content" name="absence_request[notes][content]" label="Comments" type="textarea"
-                    width="expand"></input-text>
+        <lux-input-text id="absence_request_notes_content" name="absence_request[notes][content]" label="Comments" type="textarea"
+                    width="expand"></lux-input-text>
       </grid-item>
 
       <grid-item columns="lg-12 sm-12">

--- a/app/views/absence_requests/_index_detail.html.erb
+++ b/app/views/absence_requests/_index_detail.html.erb
@@ -1,4 +1,4 @@
-<card id="<%= absence_request.id %>" size="full-width">
+<lux-card id="<%= absence_request.id %>" size="full-width">
   <card-media>
     <lux-icon-base
       width="50"
@@ -11,11 +11,11 @@
     <lux-text-style><%= absence_request.formatted_full_start_date %> to <%= absence_request.formatted_full_end_date %></lux-text-style>
   </card-header>
   <card-content class="right-align">
-    <tag type="tag" :tag-items="[
+    <lux-tag type="tag" :tag-items="[
       {name: '<%= absence_request.latest_status %>', color: '<%= absence_request.status_color %>'}
       ]"
       horizontal="end"
-      size="small"></tag>
+      size="small"></lux-tag>
     <lux-text-style type="span" variation="small"><%= absence_request.latest_status_date %></lux-text-style>
   </card-content>
-</card>
+</lux-card>

--- a/app/views/absence_requests/_index_detail.html.erb
+++ b/app/views/absence_requests/_index_detail.html.erb
@@ -1,21 +1,21 @@
 <lux-card id="<%= absence_request.id %>" size="full-width">
-  <card-media>
+  <lux-card-media>
     <lux-icon-base
       width="50"
       height="50"
       icon-color="rgb(65, 70, 78)"
     ><<%= absence_request.absence_type_icon %> /></lux-icon-base>
-  </card-media>
-  <card-header>
+  </lux-card-media>
+  <lux-card-header>
     <lux-heading level="h2" size="h3"><lux-hyperlink href="<%= absence_request_path(absence_request.to_model)%>"><%= absence_request.event_title_brief %></lux-hyperlink></lux-heading>
     <lux-text-style><%= absence_request.formatted_full_start_date %> to <%= absence_request.formatted_full_end_date %></lux-text-style>
-  </card-header>
-  <card-content class="right-align">
+  </lux-card-header>
+  <lux-card-content class="right-align">
     <lux-tag type="tag" :tag-items="[
       {name: '<%= absence_request.latest_status %>', color: '<%= absence_request.status_color %>'}
       ]"
       horizontal="end"
       size="small"></lux-tag>
     <lux-text-style type="span" variation="small"><%= absence_request.latest_status_date %></lux-text-style>
-  </card-content>
+  </lux-card-content>
 </lux-card>

--- a/app/views/absence_requests/_index_detail.html.erb
+++ b/app/views/absence_requests/_index_detail.html.erb
@@ -7,7 +7,7 @@
     ><<%= absence_request.absence_type_icon %> /></lux-icon-base>
   </card-media>
   <card-header>
-    <lux-heading level="h2" size="h3"><hyperlink href="<%= absence_request_path(absence_request.to_model)%>"><%= absence_request.event_title_brief %></hyperlink></lux-heading>
+    <lux-heading level="h2" size="h3"><lux-hyperlink href="<%= absence_request_path(absence_request.to_model)%>"><%= absence_request.event_title_brief %></lux-hyperlink></lux-heading>
     <lux-text-style><%= absence_request.formatted_full_start_date %> to <%= absence_request.formatted_full_end_date %></lux-text-style>
   </card-header>
   <card-content class="right-align">

--- a/app/views/absence_requests/_index_detail.html.erb
+++ b/app/views/absence_requests/_index_detail.html.erb
@@ -7,8 +7,8 @@
     ><<%= absence_request.absence_type_icon %> /></lux-icon-base>
   </card-media>
   <card-header>
-    <heading level="h2" size="h3"><hyperlink href="<%= absence_request_path(absence_request.to_model)%>"><%= absence_request.event_title_brief %></hyperlink></heading>
-    <text-style><%= absence_request.formatted_full_start_date %> to <%= absence_request.formatted_full_end_date %></text-style>
+    <lux-heading level="h2" size="h3"><hyperlink href="<%= absence_request_path(absence_request.to_model)%>"><%= absence_request.event_title_brief %></hyperlink></lux-heading>
+    <lux-text-style><%= absence_request.formatted_full_start_date %> to <%= absence_request.formatted_full_end_date %></lux-text-style>
   </card-header>
   <card-content class="right-align">
     <tag type="tag" :tag-items="[
@@ -16,6 +16,6 @@
       ]"
       horizontal="end"
       size="small"></tag>
-    <text-style type="span" variation="small"><%= absence_request.latest_status_date %></text-style>
+    <lux-text-style type="span" variation="small"><%= absence_request.latest_status_date %></lux-text-style>
   </card-content>
 </card>

--- a/app/views/absence_requests/_notes_card.html.erb
+++ b/app/views/absence_requests/_notes_card.html.erb
@@ -1,5 +1,5 @@
-<card size="full-width">
-    <card-content>
+<lux-card size="full-width">
+    <lux-card-content>
         <lux-heading level="h3" size="h3">
             History
           </lux-heading>
@@ -11,5 +11,5 @@
     <% if render_edit %>
       <lux-input-text id="absence_request_notes_content" name="absence_request[notes][content]" label="Notes" type="textarea" width="expand"></lux-input-text>
     <% end %>
-    </card-content>
-  </card>
+    </lux-card-content>
+  </lux-card>

--- a/app/views/absence_requests/_notes_card.html.erb
+++ b/app/views/absence_requests/_notes_card.html.erb
@@ -1,8 +1,8 @@
 <card size="full-width">
     <card-content>
-        <heading level="h3" size="h3">
+        <lux-heading level="h3" size="h3">
             History
-          </heading>
+          </lux-heading>
           <ul class="notes">
             <%= render partial: "shared/request_note", collection:
               request.notes_and_changes, as: :note %>

--- a/app/views/absence_requests/_notes_card.html.erb
+++ b/app/views/absence_requests/_notes_card.html.erb
@@ -9,7 +9,7 @@
         </ul>
 
     <% if render_edit %>
-      <input-text id="absence_request_notes_content" name="absence_request[notes][content]" label="Notes" type="textarea" width="expand"></input-text>
+      <lux-input-text id="absence_request_notes_content" name="absence_request[notes][content]" label="Notes" type="textarea" width="expand"></lux-input-text>
     <% end %>
     </card-content>
   </card>

--- a/app/views/absence_requests/_record_button.html.erb
+++ b/app/views/absence_requests/_record_button.html.erb
@@ -1,5 +1,5 @@
 <% if request.can_record?(agent: current_staff_profile) %>
   <%= form_with(model: request, local: true, url: decide_absence_request_path(request), method: :put, class: 'form-button') do |form| %>
-    <input-button type="submit" variation="solid" name="record">Mark as Recorded</input-button>
+    <lux-input-button type="submit" variation="solid" name="record">Mark as Recorded</lux-input-button>
   <% end %>
 <% end %>

--- a/app/views/absence_requests/_review_detail.html.erb
+++ b/app/views/absence_requests/_review_detail.html.erb
@@ -1,21 +1,21 @@
 <lux-card id="<%= absence_request.id %>" size="full-width">
-  <card-media>
+  <lux-card-media>
     <lux-icon-base
       width="50"
       height="50"
       icon-color="rgb(65, 70, 78)"
     ><<%= absence_request.absence_type_icon %> /></lux-icon-base>
-  </card-media>
-  <card-header>
+  </lux-card-media>
+  <lux-card-header>
     <lux-heading level="h2" size="h3"><lux-hyperlink href="<%= review_absence_request_path(absence_request.to_model)%>"><%= absence_request.creator %> - <%= absence_request.event_title_brief %></lux-hyperlink></lux-heading>
     <lux-text-style><%= absence_request.formatted_full_start_date %> to <%= absence_request.formatted_full_end_date %></lux-text-style>
-  </card-header>
-  <card-content>
+  </lux-card-header>
+  <lux-card-content>
     <lux-tag type="tag" :tag-items="[
       {name: '<%= absence_request.latest_status %>', color: '<%= absence_request.status_color %>'}
       ]"
       horizontal="end"
       size="small"></lux-tag>
     <lux-text-style type="span" variation="small"><%= absence_request.latest_status_date %></lux-text-style>
-  </card-content>
+  </lux-card-content>
 </lux-card>

--- a/app/views/absence_requests/_review_detail.html.erb
+++ b/app/views/absence_requests/_review_detail.html.erb
@@ -7,8 +7,8 @@
     ><<%= absence_request.absence_type_icon %> /></lux-icon-base>
   </card-media>
   <card-header>
-    <heading level="h2" size="h3"><hyperlink href="<%= review_absence_request_path(absence_request.to_model)%>"><%= absence_request.creator %> - <%= absence_request.event_title_brief %></hyperlink></heading>
-    <text-style><%= absence_request.formatted_full_start_date %> to <%= absence_request.formatted_full_end_date %></text-style>
+    <lux-heading level="h2" size="h3"><hyperlink href="<%= review_absence_request_path(absence_request.to_model)%>"><%= absence_request.creator %> - <%= absence_request.event_title_brief %></hyperlink></lux-heading>
+    <lux-text-style><%= absence_request.formatted_full_start_date %> to <%= absence_request.formatted_full_end_date %></lux-text-style>
   </card-header>
   <card-content>
     <tag type="tag" :tag-items="[
@@ -16,6 +16,6 @@
       ]"
       horizontal="end"
       size="small"></tag>
-    <text-style type="span" variation="small"><%= absence_request.latest_status_date %></text-style>
+    <lux-text-style type="span" variation="small"><%= absence_request.latest_status_date %></lux-text-style>
   </card-content>
 </card>

--- a/app/views/absence_requests/_review_detail.html.erb
+++ b/app/views/absence_requests/_review_detail.html.erb
@@ -7,7 +7,7 @@
     ><<%= absence_request.absence_type_icon %> /></lux-icon-base>
   </card-media>
   <card-header>
-    <lux-heading level="h2" size="h3"><hyperlink href="<%= review_absence_request_path(absence_request.to_model)%>"><%= absence_request.creator %> - <%= absence_request.event_title_brief %></hyperlink></lux-heading>
+    <lux-heading level="h2" size="h3"><lux-hyperlink href="<%= review_absence_request_path(absence_request.to_model)%>"><%= absence_request.creator %> - <%= absence_request.event_title_brief %></lux-hyperlink></lux-heading>
     <lux-text-style><%= absence_request.formatted_full_start_date %> to <%= absence_request.formatted_full_end_date %></lux-text-style>
   </card-header>
   <card-content>

--- a/app/views/absence_requests/_review_detail.html.erb
+++ b/app/views/absence_requests/_review_detail.html.erb
@@ -1,4 +1,4 @@
-<card id="<%= absence_request.id %>" size="full-width">
+<lux-card id="<%= absence_request.id %>" size="full-width">
   <card-media>
     <lux-icon-base
       width="50"
@@ -11,11 +11,11 @@
     <lux-text-style><%= absence_request.formatted_full_start_date %> to <%= absence_request.formatted_full_end_date %></lux-text-style>
   </card-header>
   <card-content>
-    <tag type="tag" :tag-items="[
+    <lux-tag type="tag" :tag-items="[
       {name: '<%= absence_request.latest_status %>', color: '<%= absence_request.status_color %>'}
       ]"
       horizontal="end"
-      size="small"></tag>
+      size="small"></lux-tag>
     <lux-text-style type="span" variation="small"><%= absence_request.latest_status_date %></lux-text-style>
   </card-content>
-</card>
+</lux-card>

--- a/app/views/absence_requests/_review_form.html.erb
+++ b/app/views/absence_requests/_review_form.html.erb
@@ -1,46 +1,46 @@
 <div >
 
   <%= form_with(model: request_change_set.model, local: true, url: decide_absence_request_path(request_change_set.model), method: :put) do |form| %>
-    <grid-container>
+    <lux-grid-container>
       <% if request_change_set.errors.any? %>
         <%=render 'errors', request_change_set: request_change_set%>
       <% end %>
 
 
-      <grid-item columns="lg-12 sm-12" order="order-lg-1">
+      <lux-grid-item columns="lg-12 sm-12" order="order-lg-1">
             <%= render 'title_card', request: request_change_set %>      
-      </grid-item>
+      </lux-grid-item>
 
-      <grid-item columns="lg-6 sm-12" order="order-lg-2 order-sm-3">
+      <lux-grid-item columns="lg-6 sm-12" order="order-lg-2 order-sm-3">
         <%= render 'notes_card', request: request_change_set, render_edit: true %>      
-      </grid-item>
-      <grid-item columns="lg-6 sm-12" order="order-lg-3 order-sm-2">
-        <card size="full-width">
-          <card-content>
+      </lux-grid-item>
+      <lux-grid-item columns="lg-6 sm-12" order="order-lg-3 order-sm-2">
+        <lux-card size="full-width">
+          <lux-card-content>
               <lux-text-style variation="strong">Team members absent during this time period</lux-text-style>
               <ul class="staff"><%=  render partial: "shared/absent_staff", collection: request_change_set.absent_staff, as: :staff %></ul>
-          </card-content>
-        </card>
+          </lux-card-content>
+        </lux-card>
         <%= render 'balances', balance_title: request_change_set.balance_title, 
                               vacation_balance:  request_change_set.vacation_balance,
                               personal_balance: request_change_set.personal_balance,
                               sick_balance: request_change_set.sick_balance  %>
 
-      </grid-item>
+      </lux-grid-item>
 
-      <grid-item columns="lg-12 sm-12" order="order-lg-4 order-sm-4">
-        <card size="full-width">
-          <card-content>
+      <lux-grid-item columns="lg-12 sm-12" order="order-lg-4 order-sm-4">
+        <lux-card size="full-width">
+          <lux-card-content>
             <%if action == 'review' %>
               <lux-input-button type="submit" variation="solid" name="approve">Approve</lux-input-button>
               <lux-input-button type="submit" variation="solid" name="deny">Deny</lux-input-button>
             <% else %>
               <lux-input-button type="submit" variation="solid" name="comment">Comment</lux-input-button>
             <% end %>
-          </card-content>
-        </card>
-      </grid-item>
+          </lux-card-content>
+        </lux-card>
+      </lux-grid-item>
 
-  </grid-container>
+  </lux-grid-container>
 <% end %>
 </div>

--- a/app/views/absence_requests/_review_form.html.erb
+++ b/app/views/absence_requests/_review_form.html.erb
@@ -32,10 +32,10 @@
         <card size="full-width">
           <card-content>
             <%if action == 'review' %>
-              <input-button type="submit" variation="solid" name="approve">Approve</input-button>
-              <input-button type="submit" variation="solid" name="deny">Deny</input-button>
+              <lux-input-button type="submit" variation="solid" name="approve">Approve</lux-input-button>
+              <lux-input-button type="submit" variation="solid" name="deny">Deny</lux-input-button>
             <% else %>
-              <input-button type="submit" variation="solid" name="comment">Comment</input-button>
+              <lux-input-button type="submit" variation="solid" name="comment">Comment</lux-input-button>
             <% end %>
           </card-content>
         </card>

--- a/app/views/absence_requests/_review_form.html.erb
+++ b/app/views/absence_requests/_review_form.html.erb
@@ -17,7 +17,7 @@
       <grid-item columns="lg-6 sm-12" order="order-lg-3 order-sm-2">
         <card size="full-width">
           <card-content>
-              <text-style variation="strong">Team members absent during this time period</text-style>
+              <lux-text-style variation="strong">Team members absent during this time period</lux-text-style>
               <ul class="staff"><%=  render partial: "shared/absent_staff", collection: request_change_set.absent_staff, as: :staff %></ul>
           </card-content>
         </card>

--- a/app/views/absence_requests/_title_card.html.erb
+++ b/app/views/absence_requests/_title_card.html.erb
@@ -1,13 +1,13 @@
-<card class="title-card" size="full-width">
+<lux-card class="title-card" size="full-width">
   <card-media>
       <lux-icon-base
       width="50"
       height="50"
       icon-color="rgb(65, 70, 78)"
     ><<%= request.absence_type_icon %> /></lux-icon-base>
-    <tag type="tag" size="small" :tag-items="[
+    <lux-tag type="tag" size="small" :tag-items="[
           {name: '<%= request.latest_status %>', color: '<%= request.status_color %>', icon: '<%= request.status_icon %>'}
-          ]"></tag>
+          ]"></lux-tag>
   </card-media>
   <card-header>
       <lux-heading level="h1" size="h3">
@@ -25,4 +25,4 @@
           >
         </div>
       </card-content>
-</card>
+</lux-card>

--- a/app/views/absence_requests/_title_card.html.erb
+++ b/app/views/absence_requests/_title_card.html.erb
@@ -10,18 +10,18 @@
           ]"></tag>
   </card-media>
   <card-header>
-      <heading level="h1" size="h3">
+      <lux-heading level="h1" size="h3">
         <span class="event-requestor"
           ><%= request.full_name %></span
         >
         <span class="event-title"><%= request.event_title %></span>
-      </heading>
+      </lux-heading>
     </card-header>
     <card-content>
         <div class="status-<%= request.status_color %>">
-          <heading level="h2" size="h3"
-            ><text-style variation="default">Total Hours</text-style><%=
-            request.hours_requested %></heading
+          <lux-heading level="h2" size="h3"
+            ><lux-text-style variation="default">Total Hours</lux-text-style><%=
+            request.hours_requested %></lux-heading
           >
         </div>
       </card-content>

--- a/app/views/absence_requests/_title_card.html.erb
+++ b/app/views/absence_requests/_title_card.html.erb
@@ -1,5 +1,5 @@
 <lux-card class="title-card" size="full-width">
-  <card-media>
+  <lux-card-media>
       <lux-icon-base
       width="50"
       height="50"
@@ -8,21 +8,21 @@
     <lux-tag type="tag" size="small" :tag-items="[
           {name: '<%= request.latest_status %>', color: '<%= request.status_color %>', icon: '<%= request.status_icon %>'}
           ]"></lux-tag>
-  </card-media>
-  <card-header>
+  </lux-card-media>
+  <lux-card-header>
       <lux-heading level="h1" size="h3">
         <span class="event-requestor"
           ><%= request.full_name %></span
         >
         <span class="event-title"><%= request.event_title %></span>
       </lux-heading>
-    </card-header>
-    <card-content>
+    </lux-card-header>
+    <lux-card-content>
         <div class="status-<%= request.status_color %>">
           <lux-heading level="h2" size="h3"
             ><lux-text-style variation="default">Total Hours</lux-text-style><%=
             request.hours_requested %></lux-heading
           >
         </div>
-      </card-content>
+      </lux-card-content>
 </lux-card>

--- a/app/views/absence_requests/comment.html.erb
+++ b/app/views/absence_requests/comment.html.erb
@@ -1,7 +1,7 @@
 <wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="lg-12 sm-12">
-      <heading level="h1" size="h2">Comment on Absence Request</heading>
+      <lux-heading level="h1" size="h2">Comment on Absence Request</lux-heading>
     </grid-item>
   </grid-container>
   

--- a/app/views/absence_requests/comment.html.erb
+++ b/app/views/absence_requests/comment.html.erb
@@ -1,9 +1,9 @@
 <wrapper :max-width=1440>
-  <grid-container>
-    <grid-item columns="lg-12 sm-12">
+  <lux-grid-container>
+    <lux-grid-item columns="lg-12 sm-12">
       <lux-heading level="h1" size="h2">Comment on Absence Request</lux-heading>
-    </grid-item>
-  </grid-container>
+    </lux-grid-item>
+  </lux-grid-container>
   
   <%= render 'review_form', request_change_set: @request_change_set, action: 'comment' %>
 

--- a/app/views/absence_requests/comment.html.erb
+++ b/app/views/absence_requests/comment.html.erb
@@ -1,4 +1,4 @@
-<wrapper :max-width=1440>
+<lux-wrapper :max-width=1440>
   <lux-grid-container>
     <lux-grid-item columns="lg-12 sm-12">
       <lux-heading level="h1" size="h2">Comment on Absence Request</lux-heading>
@@ -7,4 +7,4 @@
   
   <%= render 'review_form', request_change_set: @request_change_set, action: 'comment' %>
 
-</wrapper>
+</lux-wrapper>

--- a/app/views/absence_requests/edit.html.erb
+++ b/app/views/absence_requests/edit.html.erb
@@ -1,4 +1,4 @@
-<wrapper :max-width=1440>
+<lux-wrapper :max-width=1440>
   <lux-grid-container>
     <lux-grid-item columns="lg-12 sm-12">
       <lux-heading level="h1" size="h2">Edit Absence Request</lux-heading>
@@ -7,4 +7,4 @@
   
   <%= render 'form', request_change_set: @request_change_set %>
 
-</wrapper>
+</lux-wrapper>

--- a/app/views/absence_requests/edit.html.erb
+++ b/app/views/absence_requests/edit.html.erb
@@ -1,7 +1,7 @@
 <wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="lg-12 sm-12">
-      <heading level="h1" size="h2">Edit Absence Request</heading>
+      <lux-heading level="h1" size="h2">Edit Absence Request</lux-heading>
     </grid-item>
   </grid-container>
   

--- a/app/views/absence_requests/edit.html.erb
+++ b/app/views/absence_requests/edit.html.erb
@@ -1,9 +1,9 @@
 <wrapper :max-width=1440>
-  <grid-container>
-    <grid-item columns="lg-12 sm-12">
+  <lux-grid-container>
+    <lux-grid-item columns="lg-12 sm-12">
       <lux-heading level="h1" size="h2">Edit Absence Request</lux-heading>
-    </grid-item>
-  </grid-container>
+    </lux-grid-item>
+  </lux-grid-container>
   
   <%= render 'form', request_change_set: @request_change_set %>
 

--- a/app/views/absence_requests/new.html.erb
+++ b/app/views/absence_requests/new.html.erb
@@ -1,7 +1,7 @@
 <wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="lg-12 sm-12">
-      <heading level="h1" size="h2">New Absence Request</heading>
+      <lux-heading level="h1" size="h2">New Absence Request</lux-heading>
     </grid-item>
   </grid-container>
   

--- a/app/views/absence_requests/new.html.erb
+++ b/app/views/absence_requests/new.html.erb
@@ -1,9 +1,9 @@
 <wrapper :max-width=1440>
-  <grid-container>
-    <grid-item columns="lg-12 sm-12">
+  <lux-grid-container>
+    <lux-grid-item columns="lg-12 sm-12">
       <lux-heading level="h1" size="h2">New Absence Request</lux-heading>
-    </grid-item>
-  </grid-container>
+    </lux-grid-item>
+  </lux-grid-container>
   
 <%= render 'form', request_change_set: @request_change_set %>
 

--- a/app/views/absence_requests/new.html.erb
+++ b/app/views/absence_requests/new.html.erb
@@ -1,4 +1,4 @@
-<wrapper :max-width=1440>
+<lux-wrapper :max-width=1440>
   <lux-grid-container>
     <lux-grid-item columns="lg-12 sm-12">
       <lux-heading level="h1" size="h2">New Absence Request</lux-heading>
@@ -7,4 +7,4 @@
   
 <%= render 'form', request_change_set: @request_change_set %>
 
-</wrapper>
+</lux-wrapper>

--- a/app/views/absence_requests/review.html.erb
+++ b/app/views/absence_requests/review.html.erb
@@ -1,4 +1,4 @@
-<wrapper :max-width=1440>
+<lux-wrapper :max-width=1440>
   <lux-grid-container>
     <lux-grid-item columns="lg-12 sm-12">
       <lux-heading level="h1" size="h2">Review Absence Request</lux-heading>
@@ -7,4 +7,4 @@
   
   <%= render 'review_form', request_change_set: @request_change_set, action: 'review' %>
 
-</wrapper>
+</lux-wrapper>

--- a/app/views/absence_requests/review.html.erb
+++ b/app/views/absence_requests/review.html.erb
@@ -1,9 +1,9 @@
 <wrapper :max-width=1440>
-  <grid-container>
-    <grid-item columns="lg-12 sm-12">
+  <lux-grid-container>
+    <lux-grid-item columns="lg-12 sm-12">
       <lux-heading level="h1" size="h2">Review Absence Request</lux-heading>
-    </grid-item>
-  </grid-container>
+    </lux-grid-item>
+  </lux-grid-container>
   
   <%= render 'review_form', request_change_set: @request_change_set, action: 'review' %>
 

--- a/app/views/absence_requests/review.html.erb
+++ b/app/views/absence_requests/review.html.erb
@@ -1,7 +1,7 @@
 <wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="lg-12 sm-12">
-      <heading level="h1" size="h2">Review Absence Request</heading>
+      <lux-heading level="h1" size="h2">Review Absence Request</lux-heading>
     </grid-item>
   </grid-container>
   

--- a/app/views/absence_requests/show.html.erb
+++ b/app/views/absence_requests/show.html.erb
@@ -2,7 +2,7 @@
   <grid-container>
     <% if @request.approved? && @request.request.can_cancel?(agent: current_staff_profile) %>
     <grid-item columns="lg-12 sm-12">
-      <alert status="success" class="tip-card"><strong>Your <%= @request.title.downcase %> request has been approved.</strong> Please proceed with recording your absence in the <hyperlink href="http://www.princeton.edu/hr/progserv/sds/applications/selfservice.html" target="_blank">HR Self Service system</hyperlink> as soon as possible. Your supervisor will be confirming that you have reported this information at the end of the month.</alert>
+      <alert status="success" class="tip-card"><strong>Your <%= @request.title.downcase %> request has been approved.</strong> Please proceed with recording your absence in the <lux-hyperlink href="http://www.princeton.edu/hr/progserv/sds/applications/selfservice.html" target="_blank">HR Self Service system</lux-hyperlink> as soon as possible. Your supervisor will be confirming that you have reported this information at the end of the month.</alert>
     </grid-item>
     <% end %>
       

--- a/app/views/absence_requests/show.html.erb
+++ b/app/views/absence_requests/show.html.erb
@@ -15,7 +15,7 @@
     <grid-item columns="lg-6 sm-12" order="order-lg-3 order-sm-2" :offset="true">
       <card size="full-width">
         <card-content>
-            <text-style variation="strong">Team members absent during this time period</text-style>
+            <lux-text-style variation="strong">Team members absent during this time period</lux-text-style>
             <ul class="staff"><%=  render partial: "shared/absent_staff", collection: @request.absent_staff, as: :staff %></ul>
         </card-content>
       </card>

--- a/app/views/absence_requests/show.html.erb
+++ b/app/views/absence_requests/show.html.erb
@@ -1,31 +1,31 @@
-<wrapper :max-width=1440 class="request">
-  <grid-container>
+<lux-wrapper :max-width=1440 class="request">
+  <lux-grid-container>
     <% if @request.approved? && @request.request.can_cancel?(agent: current_staff_profile) %>
-    <grid-item columns="lg-12 sm-12">
-      <alert status="success" class="tip-card"><strong>Your <%= @request.title.downcase %> request has been approved.</strong> Please proceed with recording your absence in the <lux-hyperlink href="http://www.princeton.edu/hr/progserv/sds/applications/selfservice.html" target="_blank">HR Self Service system</lux-hyperlink> as soon as possible. Your supervisor will be confirming that you have reported this information at the end of the month.</alert>
-    </grid-item>
+    <lux-grid-item columns="lg-12 sm-12">
+      <lux-alert status="success" class="tip-card"><strong>Your <%= @request.title.downcase %> request has been approved.</strong> Please proceed with recording your absence in the <lux-hyperlink href="http://www.princeton.edu/hr/progserv/sds/applications/selfservice.html" target="_blank">HR Self Service system</lux-hyperlink> as soon as possible. Your supervisor will be confirming that you have reported this information at the end of the month.</lux-alert>
+    </lux-grid-item>
     <% end %>
       
-    <grid-item columns="lg-12 sm-12" order="order-lg-1">
+    <lux-grid-item columns="lg-12 sm-12" order="order-lg-1">
       <%= render 'title_card', request: @request %>
-    </grid-item>
-    <grid-item columns="lg-6 sm-12" order="order-lg-2 order-sm-3">
+    </lux-grid-item>
+    <lux-grid-item columns="lg-6 sm-12" order="order-lg-2 order-sm-3">
       <%= render 'notes_card', request: @request, render_edit: false %>
-    </grid-item>
-    <grid-item columns="lg-6 sm-12" order="order-lg-3 order-sm-2" :offset="true">
-      <card size="full-width">
-        <card-content>
+    </lux-grid-item>
+    <lux-grid-item columns="lg-6 sm-12" order="order-lg-3 order-sm-2" :offset="true">
+      <lux-card size="full-width">
+        <lux-card-content>
             <lux-text-style variation="strong">Team members absent during this time period</lux-text-style>
             <ul class="staff"><%=  render partial: "shared/absent_staff", collection: @request.absent_staff, as: :staff %></ul>
-        </card-content>
-      </card>
+        </lux-card-content>
+      </lux-card>
 
-    </grid-item>
-    <grid-item order="order-lg-4 order-sm-4">
+    </lux-grid-item>
+    <lux-grid-item order="order-lg-4 order-sm-4">
       <%= render 'shared/edit_button', request: @request.request, path: edit_absence_request_path(@request.request) %>
       <%= render 'shared/cancel_button', request: @request.request, path: decide_absence_request_path(@request.request) %>
       <%= render 'shared/comment_button', request: @request.request, path: comment_absence_request_path(@request.request) %>
       <%= render 'record_button', request: @request.request %>
-    </grid-item>
-  </gird-container>
-</wrapper>
+    </lux-grid-item>
+  </lux-grid-container>
+</lux-wrapper>

--- a/app/views/delegates/_assume_detail.html.erb
+++ b/app/views/delegates/_assume_detail.html.erb
@@ -1,13 +1,13 @@
-<card id="<%= delegator.id %>" size="full-width" class="delegate">
-  <card-media>
+<lux-card id="<%= delegator.id %>" size="full-width" class="delegate">
+  <lux-card-media>
     <lux-icon-base
       width="50"
       height="50"
       icon-color="rgb(65, 70, 78)"
     ><lux-icon-person></lux-icon-person></lux-icon-base>
-  </card-media>
-  <card-header>
+  </lux-card-media>
+  <lux-card-header>
     <lux-heading level="h2" size="h3"><lux-hyperlink href="<%= assume_delegate_path(delegator) %>"><%= delegator.delegator %></lux-hyperlink></lux-heading>
     <lux-text-style><%= delegator.delegator.uid %></lux-text-style>
-  </card-header>
-</card>
+  </lux-card-header>
+</lux-card>

--- a/app/views/delegates/_assume_detail.html.erb
+++ b/app/views/delegates/_assume_detail.html.erb
@@ -7,7 +7,7 @@
     ><lux-icon-person></lux-icon-person></lux-icon-base>
   </card-media>
   <card-header>
-    <lux-heading level="h2" size="h3"><hyperlink href="<%= assume_delegate_path(delegator) %>"><%= delegator.delegator %></hyperlink></lux-heading>
+    <lux-heading level="h2" size="h3"><lux-hyperlink href="<%= assume_delegate_path(delegator) %>"><%= delegator.delegator %></lux-hyperlink></lux-heading>
     <lux-text-style><%= delegator.delegator.uid %></lux-text-style>
   </card-header>
 </card>

--- a/app/views/delegates/_assume_detail.html.erb
+++ b/app/views/delegates/_assume_detail.html.erb
@@ -7,7 +7,7 @@
     ><lux-icon-person></lux-icon-person></lux-icon-base>
   </card-media>
   <card-header>
-    <heading level="h2" size="h3"><hyperlink href="<%= assume_delegate_path(delegator) %>"><%= delegator.delegator %></hyperlink></heading>
-    <text-style><%= delegator.delegator.uid %></text-style>
+    <lux-heading level="h2" size="h3"><hyperlink href="<%= assume_delegate_path(delegator) %>"><%= delegator.delegator %></hyperlink></lux-heading>
+    <lux-text-style><%= delegator.delegator.uid %></lux-text-style>
   </card-header>
 </card>

--- a/app/views/delegates/_form.html.erb
+++ b/app/views/delegates/_form.html.erb
@@ -12,14 +12,14 @@
     </div>
   <% end %>
 
-  <input-autocomplete required
+  <lux-autocomplete-input required
     id="delegate_delegate_id"
     name="delegate[delegate_id]"
     label="Assign people to use this system on your behalf"
     :items="<%= @staff_list %>"
-  ></input-autocomplete>
+  ></lux-autocomplete-input>
 
   <div class="actions">
-    <input-button type="submit" variation="solid">Add Delegate</input-button>
+    <lux-input-button type="submit" variation="solid">Add Delegate</lux-input-button>
   </div>
 <% end %>

--- a/app/views/delegates/_index_detail.html.erb
+++ b/app/views/delegates/_index_detail.html.erb
@@ -1,13 +1,13 @@
-<card id="<%= delegate.id %>" size="full-width" class="delegate">
-  <card-media>
+<lux-card id="<%= delegate.id %>" size="full-width" class="delegate">
+  <lux-card-media>
     <%= link_to delegate, method: :delete do %>
       <lux-icon-base width="50" height="50" icon-name="Remove Delegate" icon-color="red">
         <lux-icon-denied></lux-icon-denied>
       </lux-icon-base>
     <% end %>
-  </card-media>
-  <card-header>
+  </lux-card-media>
+  <lux-card-header>
     <lux-heading level="h2" size="h3"><%= delegate.delegate %></lux-heading>
     <lux-text-style><%= delegate.delegate.uid %></lux-text-style>
-  </card-header>
-</card>
+  </lux-card-header>
+</lux-card>

--- a/app/views/delegates/_index_detail.html.erb
+++ b/app/views/delegates/_index_detail.html.erb
@@ -7,7 +7,7 @@
     <% end %>
   </card-media>
   <card-header>
-    <heading level="h2" size="h3"><%= delegate.delegate %></heading>
-    <text-style><%= delegate.delegate.uid %></text-style>
+    <lux-heading level="h2" size="h3"><%= delegate.delegate %></lux-heading>
+    <lux-text-style><%= delegate.delegate.uid %></lux-text-style>
   </card-header>
 </card>

--- a/app/views/delegates/index.html.erb
+++ b/app/views/delegates/index.html.erb
@@ -32,5 +32,5 @@
       <% end %>
     </lux-grid-item>
   </lux-grid-container>
-</wrapper>
+</lux-wrapper>
 <br/>

--- a/app/views/delegates/index.html.erb
+++ b/app/views/delegates/index.html.erb
@@ -1,36 +1,36 @@
-<wrapper :max-width=1440>
-  <grid-container>
-    <grid-item columns="lg-12 sm-12">
+<lux-wrapper :max-width=1440>
+  <lux-grid-container>
+    <lux-grid-item columns="lg-12 sm-12">
       <lux-heading level="h1" size="h2">My Delegates</lux-heading>
-    </grid-item>
-  </grid-container>
-</wrapper>
-<wrapper :max-width=1440 class="my-delegates">
-  <grid-container>
-    <grid-item columns="lg-12 sm-12">
-      <alert status="info" class="tip-card">Please use this feature with care as it allows other people whom you designate to act on your behalf.</alert>
-    </grid-item>
-    <grid-item columns="lg-12 sm-12">
-      <card size="full-width" class="search-filter-sort">
-        <card-content>
-          <grid-container>
-            <grid-item columns="lg-12 sm-12">
+    </lux-grid-item>
+  </lux-grid-container>
+</lux-wrapper>
+<lux-wrapper :max-width=1440 class="my-delegates">
+  <lux-grid-container>
+    <lux-grid-item columns="lg-12 sm-12">
+      <lux-alert status="info" class="tip-card">Please use this feature with care as it allows other people whom you designate to act on your behalf.</lux-alert>
+    </lux-grid-item>
+    <lux-grid-item columns="lg-12 sm-12">
+      <lux-card size="full-width" class="search-filter-sort">
+        <lux-card-content>
+          <lux-grid-container>
+            <lux-grid-item columns="lg-12 sm-12">
               <%= render 'form', delegate: @delegate %>
-            </grid-item>
-          </grid-container>
-        </card-content>
-      </card>
-    </grid-item>
-  </grid-container>
-  <grid-container>
-    <grid-item columns="lg-12 sm-12">
+            </lux-grid-item>
+          </lux-grid-container>
+        </lux-card-content>
+      </lux-card>
+    </lux-grid-item>
+  </lux-grid-container>
+  <lux-grid-container>
+    <lux-grid-item columns="lg-12 sm-12">
       <% if @delegates.count == 0 %>
         <lux-heading id="no-delegates" level="h3" size="h3">You don't have any delegates at the moment.</lux-heading>
       <% end %>
       <% @delegates.each do |delegate| %>
         <%=  render 'index_detail', delegate: delegate %>
       <% end %>
-    </grid-item>
-  </grid-container>
+    </lux-grid-item>
+  </lux-grid-container>
 </wrapper>
 <br/>

--- a/app/views/delegates/index.html.erb
+++ b/app/views/delegates/index.html.erb
@@ -1,7 +1,7 @@
 <wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="lg-12 sm-12">
-      <heading level="h1" size="h2">My Delegates</heading>
+      <lux-heading level="h1" size="h2">My Delegates</lux-heading>
     </grid-item>
   </grid-container>
 </wrapper>
@@ -25,7 +25,7 @@
   <grid-container>
     <grid-item columns="lg-12 sm-12">
       <% if @delegates.count == 0 %>
-        <heading id="no-delegates" level="h3" size="h3">You don't have any delegates at the moment.</heading>
+        <lux-heading id="no-delegates" level="h3" size="h3">You don't have any delegates at the moment.</lux-heading>
       <% end %>
       <% @delegates.each do |delegate| %>
         <%=  render 'index_detail', delegate: delegate %>

--- a/app/views/delegates/to_assume.html.erb
+++ b/app/views/delegates/to_assume.html.erb
@@ -1,7 +1,7 @@
 <wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="lg-12 sm-12">
-      <heading level="h1" size="h2">Act as Delegate for...</heading>
+      <lux-heading level="h1" size="h2">Act as Delegate for...</lux-heading>
     </grid-item>
   </grid-container>
 </wrapper>
@@ -12,7 +12,7 @@
     </grid-item>
     <grid-item columns="lg-12 sm-12">
       <% if @delegators.count == 0 %>
-        <heading id="no-delegates" level="h3" size="h3">You don't have any people you can become at the moment.</heading>
+        <lux-heading id="no-delegates" level="h3" size="h3">You don't have any people you can become at the moment.</lux-heading>
       <% end %>
       <% @delegators.each do |delegator| %>
         <%=  render 'assume_detail', delegator: delegator %>

--- a/app/views/delegates/to_assume.html.erb
+++ b/app/views/delegates/to_assume.html.erb
@@ -1,23 +1,23 @@
-<wrapper :max-width=1440>
-  <grid-container>
-    <grid-item columns="lg-12 sm-12">
+<lux-wrapper :max-width=1440>
+  <lux-grid-container>
+    <lux-grid-item columns="lg-12 sm-12">
       <lux-heading level="h1" size="h2">Act as Delegate for...</lux-heading>
-    </grid-item>
-  </grid-container>
-</wrapper>
-<wrapper :max-width=1440 class="my-delegates">
-  <grid-container>
-    <grid-item columns="lg-12 sm-12">
-      <alert status="info" class="tip-card">Please use this feature with care as it allows you to act on someone's behalf.</alert>
-    </grid-item>
-    <grid-item columns="lg-12 sm-12">
+    </lux-grid-item>
+  </lux-grid-container>
+</lux-wrapper>
+<lux-wrapper :max-width=1440 class="my-delegates">
+  <lux-grid-container>
+    <lux-grid-item columns="lg-12 sm-12">
+      <lux-alert status="info" class="tip-card">Please use this feature with care as it allows you to act on someone's behalf.</lux-alert>
+    </lux-grid-item>
+    <lux-grid-item columns="lg-12 sm-12">
       <% if @delegators.count == 0 %>
         <lux-heading id="no-delegates" level="h3" size="h3">You don't have any people you can become at the moment.</lux-heading>
       <% end %>
       <% @delegators.each do |delegator| %>
         <%=  render 'assume_detail', delegator: delegator %>
       <% end %>
-    </grid-item>
-  </grid-container>
-</wrapper>
+    </lux-grid-item>
+  </lux-grid-container>
+</lux-wrapper>
 <br/>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,8 +1,8 @@
 <wrapper>
-  <grid-container class="stretch-height">
-    <grid-item >
+  <lux-grid-container class="stretch-height">
+    <lux-grid-item >
       <lux-text-style variation="default">You must login to view the requested resource.</lux-text-style>
       <lux-hyperlink href="/users/auth/cas" variation="button solid" data-method="post" size="large">LOGIN with NetID</lux-hyperlink>
-    </grid-item>
-  </grid-container>
+    </lux-grid-item>
+  </lux-grid-container>
 </wrapper>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,8 +1,8 @@
-<wrapper>
+<lux-wrapper>
   <lux-grid-container class="stretch-height">
     <lux-grid-item >
       <lux-text-style variation="default">You must login to view the requested resource.</lux-text-style>
       <lux-hyperlink href="/users/auth/cas" variation="button solid" data-method="post" size="large">LOGIN with NetID</lux-hyperlink>
     </lux-grid-item>
   </lux-grid-container>
-</wrapper>
+</lux-wrapper>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,7 +2,7 @@
   <grid-container class="stretch-height">
     <grid-item >
       <lux-text-style variation="default">You must login to view the requested resource.</lux-text-style>
-      <hyperlink href="/users/auth/cas" variation="button solid" data-method="post" size="large">LOGIN with NetID</hyperlink>
+      <lux-hyperlink href="/users/auth/cas" variation="button solid" data-method="post" size="large">LOGIN with NetID</lux-hyperlink>
     </grid-item>
   </grid-container>
 </wrapper>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <wrapper>
   <grid-container class="stretch-height">
     <grid-item >
-      <text-style variation="default">You must login to view the requested resource.</text-style>
+      <lux-text-style variation="default">You must login to view the requested resource.</lux-text-style>
       <hyperlink href="/users/auth/cas" variation="button solid" data-method="post" size="large">LOGIN with NetID</hyperlink>
     </grid-item>
   </grid-container>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,30 +12,30 @@
   </head>
 
   <body>
-    <library-header app-name="Absence and Travel Requests" abbr-name="LTR" app-url="<%= HomeURL.for(current_user: current_user) %>" class="lux" :max-width=1440 theme="dark">
-    <menu-bar type="main-menu" :menu-items="[
-        <% if current_user %>
-          {name: 'Requests', component: 'My Requests', children: [
-            {name: 'New Travel Request', component: 'New Travel Request', href: '/travel_requests/new/'},
-            <% if Rails.configuration.show_absence_button %>
-            {name: 'New Absence Request', component: 'New Absence Request', href: '/absence_requests/new/'},
+    <lux-library-header app-name="Absence and Travel Requests" abbr-name="LTR" app-url="<%= HomeURL.for(current_user: current_user) %>" class="lux" :max-width=1440 theme="dark">
+      <lux-menu-bar type="main-menu" :menu-items="[
+          <% if current_user %>
+            {name: 'Requests', component: 'My Requests', children: [
+              {name: 'New Travel Request', component: 'New Travel Request', href: '/travel_requests/new/'},
+              <% if Rails.configuration.show_absence_button %>
+              {name: 'New Absence Request', component: 'New Absence Request', href: '/absence_requests/new/'},
+              <% end %>
+              {name: 'My Requests', component: 'My Requests', href: '/my_requests/'},
+              {name: 'Reports', component: 'Reports', href: '/reports/'},
+            ]},
+            <%= "{name: 'Requests to Review', component: 'Requests to Review', href: '/my_approval_requests/'}," if current_staff_profile.supervisor? %>
+            {name: '<%= current_user %>', component: 'My Requests', children: [
+              <% unless current_delegate %>
+              {name: 'My Delegates', component: 'My Delegates', href: '/delegates/'},
+              {name: 'My Delegations', component: 'Delegations', href: '<%= to_assume_delegates_path %>'},
             <% end %>
-            {name: 'My Requests', component: 'My Requests', href: '/my_requests/'},
-            {name: 'Reports', component: 'Reports', href: '/reports/'},
-          ]},
-          <%= "{name: 'Requests to Review', component: 'Requests to Review', href: '/my_approval_requests/'}," if current_staff_profile.supervisor? %>
-          {name: '<%= current_user %>', component: 'My Requests', children: [
-            <% unless current_delegate %>
-            {name: 'My Delegates', component: 'My Delegates', href: '/delegates/'},
-            {name: 'My Delegations', component: 'Delegations', href: '<%= to_assume_delegates_path %>'},
+              {name: 'Help', component: 'Help', href: '/help'},
+              {name: 'Logout', component: 'Logout', href: '/sign_out'},
+            ]},
+            
           <% end %>
-            {name: 'Help', component: 'Help', href: '/help'},
-            {name: 'Logout', component: 'Logout', href: '/sign_out'},
-          ]},
-          
-        <% end %>
-      ]"></menu-bar>
-    </library-header>
+        ]"></lux-menu-bar>
+    </lux-library-header>
     <% if current_delegate %>
       <div class="lux">
         <alert status="info" class="current-delegate">
@@ -54,9 +54,9 @@
     <% end %>
     <div class="main-content">
       <div class="lux">
-        <wrapper :max-width=1400>
+        <lux-wrapper :max-width=1400>
           <%= render 'shared/flash_messages' %>
-        </wrapper>
+        </lux-wrapper>
         <%= yield %>
       </div>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,8 +11,8 @@
     <%= vite_javascript_tag 'application' %>
   </head>
 
-  <body>
-    <lux-library-header app-name="Absence and Travel Requests" abbr-name="LTR" app-url="<%= HomeURL.for(current_user: current_user) %>" class="lux" :max-width=1440 theme="dark">
+  <body class="lux">
+    <lux-library-header app-name="Absence and Travel Requests" abbr-name="LTR" app-url="<%= HomeURL.for(current_user: current_user) %>" :max-width=1440 theme="dark">
       <lux-menu-bar type="main-menu" :menu-items="[
           <% if current_user %>
             {name: 'Requests', component: 'My Requests', children: [
@@ -37,8 +37,8 @@
         ]"></lux-menu-bar>
     </lux-library-header>
     <% if current_delegate %>
-      <div class="lux">
-        <alert status="info" class="current-delegate">
+      <div>
+        <lux-alert status="info" class="current-delegate">
           <lux-icon-base
             width="24"
             height="24"
@@ -47,13 +47,13 @@
           <lux-hyperlink href="<%= cancel_delegates_path %>" variation="button outline" id="cancel_delegation"><lux-icon-base width="16" height="16" icon-name="Remove Delegate">
             <lux-icon-denied></lux-icon-denied>
           </lux-icon-base> Stop acting on 
-          <%= current_delegate.delegator.given_name%>'s behalf.</hyperlink>
+          <%= current_delegate.delegator.given_name%>'s behalf.</lux-hyperlink>
           <p>Please use this feature with care as it allows you to act on someone's behalf.</p>
-        </alert>
+        </lux-alert>
       </div>
     <% end %>
     <div class="main-content">
-      <div class="lux">
+      <div>
         <lux-wrapper :max-width=1400>
           <%= render 'shared/flash_messages' %>
         </lux-wrapper>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,7 +44,7 @@
             height="24"
             icon-color="rgb(65, 70, 78)"
           ><lux-icon-person></lux-icon-person></lux-icon-base> You are acting on behalf of <%= current_delegate.delegator %>. 
-          <hyperlink href="<%= cancel_delegates_path %>" variation="button outline" id="cancel_delegation"><lux-icon-base width="16" height="16" icon-name="Remove Delegate">
+          <lux-hyperlink href="<%= cancel_delegates_path %>" variation="button outline" id="cancel_delegation"><lux-icon-base width="16" height="16" icon-name="Remove Delegate">
             <lux-icon-denied></lux-icon-denied>
           </lux-icon-base> Stop acting on 
           <%= current_delegate.delegator.given_name%>'s behalf.</hyperlink>

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -82,7 +82,7 @@
       <lux-card size="full-width">
         <lux-card-content>
           <lux-heading level="h2" size="h3" id="report-problem">Report a Problem</lux-heading>
-          <alert class="tip-card">Please use the latest version of Chrome, Edge, or Firefox to use this application. Internet Explorer is not supported.</alert>
+          <lux-alert class="tip-card">Please use the latest version of Chrome, Edge, or Firefox to use this application. Internet Explorer is not supported.</lux-alert>
           <lux-text-style>If you are looking for technical support or would like to provide feedback on this application, please contact <%= mail_to "lsupport@princeton.edu", "lsupport@princeton.edu" %>.</lux-text-style>
           <lux-text-style><strong>Note</strong>: When reporting issues, please include screenshots, if possible.</lux-text-style>
         </lux-card-content>

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -1,8 +1,8 @@
-<wrapper :max-width="1440">
-  <grid-container class="help">
-    <grid-item columns="lg-3 sm-12">
-    <card size="full-width" class="help-sidebar">
-      <card-content>
+<lux-wrapper :max-width="1440">
+  <lux-grid-container class="help">
+    <lux-grid-item columns="lg-3 sm-12">
+    <lux-card size="full-width" class="help-sidebar">
+      <lux-card-content>
         <lux-heading level="h2" size="h4">Helpful Guides</lux-heading>
         <ul>
           <li><%= link_to "Create a Travel Request", :anchor => "create-travel" %></li>
@@ -10,13 +10,13 @@
           <li><%= link_to "Cancel a Travel Request", :anchor => "cancel-travel" %></li>
           <li><%= link_to "Report a Problem", :anchor => "report-problem" %></li>
         </ul>
-      </card-content>
-    </card>
-    </grid-item>
+      </lux-card-content>
+    </lux-card>
+    </lux-grid-item>
 
-    <grid-item columns="lg-9 sm-12">
-      <card size="full-width">
-        <card-content>
+    <lux-grid-item columns="lg-9 sm-12">
+      <lux-card size="full-width">
+        <lux-card-content>
           <lux-heading level="h1" size="h3">Overview</lux-heading>
           <p>This Absence and Travel Request application allows Library staff to seek approval for travel and absence. The initial rollout of this system supports the travel workflow. Please review the documentation below if you need assistance.</p>
           <p>Travel requests will need to be approved by your direct supervisor and any supervisors up to and including your department head. If you need clarification on travel policy, please read <%= link_to "the Library's official travel policy", "https://library.princeton.edu/staff/ofa/finance-and-budget/travel" %> or contact your direct supervisor.</p>
@@ -55,10 +55,10 @@
           <%= image_tag("requestview.png")%>
           <lux-text-style>You will receive notifications when the status of your request changes.</lux-text-style>
           <lux-text-style>You can modify your request until it has been reviewed</lux-text-style>
-        </card-content>
-      </card>
-      <card size="full-width">
-        <card-content>
+        </lux-card-content>
+      </lux-card>
+      <lux-card size="full-width">
+        <lux-card-content>
           <lux-heading level="h2" size="h3" id="approve-travel">Review a Travel Request</lux-heading>
           <lux-text-style>When there is a request to review, you will receive a notification via email with a link to that request.</lux-text-style>
           <lux-text-style>To approve a travel request pending your review, log into the system via CAS using your NetID and password.</lux-text-style>
@@ -70,23 +70,23 @@
           <lux-text-style>At this point you may also "Request Changes" by adding notes and clicking on the "Request Changes" button. For example, anticipated expenses that will not be covered by the University should be requested to be deleted.</lux-text-style>
           <lux-text-style>You will receive notifications when the status of the request changes.</lux-text-style>
           <lux-text-style>The department head will have the ability to choose the travel category (business or professional development).</lux-text-style>
-        </card-content>
-      </card>
-      <card size="full-width">
-        <card-content>
+        </lux-card-content>
+      </lux-card>
+      <lux-card size="full-width">
+        <lux-card-content>
           <lux-heading level="h2" size="h3" id="cancel-travel">Cancel a Travel Request</lux-heading>
           <lux-text-style>Only the request creator can cancel their request. To cancel your request, find your request in your "My Requests" list, view your request details and click on the "Cancel" button at the bottom of the travel request details page.</lux-text-style>
           <%= image_tag("cancel_request.png")%>
-        </card-content>
-      </card>
-      <card size="full-width">
-        <card-content>
+        </lux-card-content>
+      </lux-card>
+      <lux-card size="full-width">
+        <lux-card-content>
           <lux-heading level="h2" size="h3" id="report-problem">Report a Problem</lux-heading>
           <alert class="tip-card">Please use the latest version of Chrome, Edge, or Firefox to use this application. Internet Explorer is not supported.</alert>
           <lux-text-style>If you are looking for technical support or would like to provide feedback on this application, please contact <%= mail_to "lsupport@princeton.edu", "lsupport@princeton.edu" %>.</lux-text-style>
           <lux-text-style><strong>Note</strong>: When reporting issues, please include screenshots, if possible.</lux-text-style>
-        </card-content>
-      </card>
-    </grid-item>
-  </grid-container>
-</wrapper>
+        </lux-card-content>
+      </lux-card>
+    </lux-grid-item>
+  </lux-grid-container>
+</lux-wrapper>

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -21,10 +21,10 @@
           <p>This Absence and Travel Request application allows Library staff to seek approval for travel and absence. The initial rollout of this system supports the travel workflow. Please review the documentation below if you need assistance.</p>
           <p>Travel requests will need to be approved by your direct supervisor and any supervisors up to and including your department head. If you need clarification on travel policy, please read <%= link_to "the Library's official travel policy", "https://library.princeton.edu/staff/ofa/finance-and-budget/travel" %> or contact your direct supervisor.</p>
           <p>Previous trainings are available to view via Google Drive. Watch the recorded session for <a href="https://drive.google.com/a/princeton.edu/file/d/1fCoa9NSSKPX9PukTF42aSR7MMROY0ylh/view?usp=sharing">requestors</a> and <a href="https://drive.google.com/a/princeton.edu/file/d/1kYowKI0-PrcaGiCXPU4Qy5gUf5bsJBcY/view?usp=sharing">approvers</a>.</p>
-        </card-content>
-      </card>
-      <card size="full-width">
-        <card-content>
+        </lux-card-content>
+      </lux-card>
+      <lux-card size="full-width">
+        <lux-card-content>
           <lux-heading level="h2" size="h3" id="create-travel">Create a Travel Request</lux-heading>
           <lux-text-style>To create a new travel request, log into the system via CAS using your NetID and password.</lux-text-style>
           <%= image_tag("login.png")%>

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -3,7 +3,7 @@
     <grid-item columns="lg-3 sm-12">
     <card size="full-width" class="help-sidebar">
       <card-content>
-        <heading level="h2" size="h4">Helpful Guides</heading>
+        <lux-heading level="h2" size="h4">Helpful Guides</lux-heading>
         <ul>
           <li><%= link_to "Create a Travel Request", :anchor => "create-travel" %></li>
           <li><%= link_to "Review a Travel Request", :anchor => "approve-travel" %></li>
@@ -17,7 +17,7 @@
     <grid-item columns="lg-9 sm-12">
       <card size="full-width">
         <card-content>
-          <heading level="h1" size="h3">Overview</heading>
+          <lux-heading level="h1" size="h3">Overview</lux-heading>
           <p>This Absence and Travel Request application allows Library staff to seek approval for travel and absence. The initial rollout of this system supports the travel workflow. Please review the documentation below if you need assistance.</p>
           <p>Travel requests will need to be approved by your direct supervisor and any supervisors up to and including your department head. If you need clarification on travel policy, please read <%= link_to "the Library's official travel policy", "https://library.princeton.edu/staff/ofa/finance-and-budget/travel" %> or contact your direct supervisor.</p>
           <p>Previous trainings are available to view via Google Drive. Watch the recorded session for <a href="https://drive.google.com/a/princeton.edu/file/d/1fCoa9NSSKPX9PukTF42aSR7MMROY0ylh/view?usp=sharing">requestors</a> and <a href="https://drive.google.com/a/princeton.edu/file/d/1kYowKI0-PrcaGiCXPU4Qy5gUf5bsJBcY/view?usp=sharing">approvers</a>.</p>
@@ -25,12 +25,12 @@
       </card>
       <card size="full-width">
         <card-content>
-          <heading level="h2" size="h3" id="create-travel">Create a Travel Request</heading>
-          <text-style>To create a new travel request, log into the system via CAS using your NetID and password.</text-style>
+          <lux-heading level="h2" size="h3" id="create-travel">Create a Travel Request</lux-heading>
+          <lux-text-style>To create a new travel request, log into the system via CAS using your NetID and password.</lux-text-style>
           <%= image_tag("login.png")%>
-          <text-style>Click on the "New Travel Request" button on the top right portion of the "My Requests" page or "New Travel Request" under the Requests menu from any page.</text-style>
+          <lux-text-style>Click on the "New Travel Request" button on the top right portion of the "My Requests" page or "New Travel Request" under the Requests menu from any page.</lux-text-style>
           <%= image_tag("my_requests.png")%>
-          <text-style>Include the details of your travel in the following fields:</text-style>
+          <lux-text-style>Include the details of your travel in the following fields:</lux-text-style>
           <%= image_tag("travel_info.png")%>
           <ul>
             <li><strong>Event Name</strong>: The name of the event you are attending, e.g., American Library Association - Annual Conference (ALA).</li>
@@ -41,7 +41,7 @@
             <li><strong>Purpose</strong>: Specify the reason this trip is necessary for your job.</li>
             <li><strong>Notes to Approvers</strong>: Additional information that would help the approver understand the details of the trip (request for time off, desire to stay additional nights, etc.). Please contact your direct supervisor for more information on what they are expecting.</li>
           </ul>
-          <text-style>Include all anticipated travel expenses related to the event you would like to attend:</text-style>
+          <lux-text-style>Include all anticipated travel expenses related to the event you would like to attend:</lux-text-style>
           <%= image_tag("expenses.png")%>
           <ul>
             <li><strong>Expense Type</strong>: The category for the anticipated line item expense.</li>
@@ -50,41 +50,41 @@
             <li><strong>Note</strong>: Additional information that would help the approver understand the details of the line item expense.</li>
             <li><strong>Total</strong>: This amount is automatically calculated based on the numbers provided for <em>Occurrences</em> and <em>Cost per Occurrences</em>.</li>
           </ul>
-          <text-style>You can add additional line item expenses by clicking on the "Add Expense" button located below the last line item expense.</text-style>
-          <text-style>Once you click on "Submit Request", a notification will be sent to your supervisor to approve the request.</text-style>
+          <lux-text-style>You can add additional line item expenses by clicking on the "Add Expense" button located below the last line item expense.</lux-text-style>
+          <lux-text-style>Once you click on "Submit Request", a notification will be sent to your supervisor to approve the request.</lux-text-style>
           <%= image_tag("requestview.png")%>
-          <text-style>You will receive notifications when the status of your request changes.</text-style>
-          <text-style>You can modify your request until it has been reviewed</text-style>
+          <lux-text-style>You will receive notifications when the status of your request changes.</lux-text-style>
+          <lux-text-style>You can modify your request until it has been reviewed</lux-text-style>
         </card-content>
       </card>
       <card size="full-width">
         <card-content>
-          <heading level="h2" size="h3" id="approve-travel">Review a Travel Request</heading>
-          <text-style>When there is a request to review, you will receive a notification via email with a link to that request.</text-style>
-          <text-style>To approve a travel request pending your review, log into the system via CAS using your NetID and password.</text-style>
-          <text-style>You can also click on "Requests to Review" on the top right navigation to view all travel requests awaiting your approval.</text-style>
+          <lux-heading level="h2" size="h3" id="approve-travel">Review a Travel Request</lux-heading>
+          <lux-text-style>When there is a request to review, you will receive a notification via email with a link to that request.</lux-text-style>
+          <lux-text-style>To approve a travel request pending your review, log into the system via CAS using your NetID and password.</lux-text-style>
+          <lux-text-style>You can also click on "Requests to Review" on the top right navigation to view all travel requests awaiting your approval.</lux-text-style>
           <%= image_tag("review_list.png")%>
-          <text-style>Review the details of travel request, add notes, approve the request.</text-style>
+          <lux-text-style>Review the details of travel request, add notes, approve the request.</lux-text-style>
           <%= image_tag("approval.png")%>
-          <text-style>In order to decline a travel request, you must include a reason in the note field.</text-style>
-          <text-style>At this point you may also "Request Changes" by adding notes and clicking on the "Request Changes" button. For example, anticipated expenses that will not be covered by the University should be requested to be deleted.</text-style>
-          <text-style>You will receive notifications when the status of the request changes.</text-style>
-          <text-style>The department head will have the ability to choose the travel category (business or professional development).</text-style>
+          <lux-text-style>In order to decline a travel request, you must include a reason in the note field.</lux-text-style>
+          <lux-text-style>At this point you may also "Request Changes" by adding notes and clicking on the "Request Changes" button. For example, anticipated expenses that will not be covered by the University should be requested to be deleted.</lux-text-style>
+          <lux-text-style>You will receive notifications when the status of the request changes.</lux-text-style>
+          <lux-text-style>The department head will have the ability to choose the travel category (business or professional development).</lux-text-style>
         </card-content>
       </card>
       <card size="full-width">
         <card-content>
-          <heading level="h2" size="h3" id="cancel-travel">Cancel a Travel Request</heading>
-          <text-style>Only the request creator can cancel their request. To cancel your request, find your request in your "My Requests" list, view your request details and click on the "Cancel" button at the bottom of the travel request details page.</text-style>
+          <lux-heading level="h2" size="h3" id="cancel-travel">Cancel a Travel Request</lux-heading>
+          <lux-text-style>Only the request creator can cancel their request. To cancel your request, find your request in your "My Requests" list, view your request details and click on the "Cancel" button at the bottom of the travel request details page.</lux-text-style>
           <%= image_tag("cancel_request.png")%>
         </card-content>
       </card>
       <card size="full-width">
         <card-content>
-          <heading level="h2" size="h3" id="report-problem">Report a Problem</heading>
+          <lux-heading level="h2" size="h3" id="report-problem">Report a Problem</lux-heading>
           <alert class="tip-card">Please use the latest version of Chrome, Edge, or Firefox to use this application. Internet Explorer is not supported.</alert>
-          <text-style>If you are looking for technical support or would like to provide feedback on this application, please contact <%= mail_to "lsupport@princeton.edu", "lsupport@princeton.edu" %>.</text-style>
-          <text-style><strong>Note</strong>: When reporting issues, please include screenshots, if possible.</text-style>
+          <lux-text-style>If you are looking for technical support or would like to provide feedback on this application, please contact <%= mail_to "lsupport@princeton.edu", "lsupport@princeton.edu" %>.</lux-text-style>
+          <lux-text-style><strong>Note</strong>: When reporting issues, please include screenshots, if possible.</lux-text-style>
         </card-content>
       </card>
     </grid-item>

--- a/app/views/requests/_date_filter.html.erb
+++ b/app/views/requests/_date_filter.html.erb
@@ -2,12 +2,12 @@
   <% params_manager.date_form_hidden_field.each do |key, value|%>
     <input type="hidden" id="<%=key%>" name="<%=key%>" value="<%=value%>"/>
   <% end %>
-  <search-box>
-      <date-picker id="dateRange" name="filters[date]" aria-label="date filter mm-dd-yyyy - mm-dd-yyyy" mode="range" 
+  <lux-search-box>
+      <lux-date-picker id="dateRange" name="filters[date]" aria-label="date filter mm-dd-yyyy - mm-dd-yyyy" mode="range" 
       <% if params_manager.date_defaults.present? %>
         :default-dates="<%= params_manager.date_defaults%>"
       <% end %>
-      ></date-picker> 
-      <input-button type="filter" id="date-filter" variation="text" aria-label="submit date filter">Filter by Date</input-button>
-  </search-box>
+      ></lux-date-picker> 
+      <lux-input-button type="filter" id="date-filter" variation="text" aria-label="submit date filter">Filter by Date</lux-input-button>
+  </lux-search-box>
 <% end %>

--- a/app/views/requests/_filter_removal.html.erb
+++ b/app/views/requests/_filter_removal.html.erb
@@ -1,10 +1,10 @@
 <% if filter_removal_urls.present? %>
   <div class="filter-applied">
     <span class="filter-label">Filtered by</span>
-    <tag type="filter" :tag-items="[
+    <lux-tag type="filter" :tag-items="[
       <% filter_removal_urls.each do |key, url| %>
       {name: '<%= key %>', href: '<%= url %>'},
       <% end %>
-    ]"></tag>
+    ]"></lux-tag>
   </div>
 <% end %>

--- a/app/views/requests/_pagination.html.erb
+++ b/app/views/requests/_pagination.html.erb
@@ -1,9 +1,9 @@
-<wrapper :max-width=1440 class="my-request">
-  <grid-container horizontal="center">
+<lux-wrapper :max-width=1440 class="my-request">
+  <lux-grid-container horizontal="center">
     <% if requests.total_pages >= 2 %>
-      <grid-item columns="auto sm-12">
+      <lux-grid-item columns="auto sm-12">
         <%= paginate requests %>
-      </grid-item>
+      </lux-grid-item>
     <% end %>
-  </grid-container>
-</wrapper>
+  </lux-grid-container>
+</lux-wrapper>

--- a/app/views/requests/_report_list.html.erb
+++ b/app/views/requests/_report_list.html.erb
@@ -48,7 +48,7 @@
         <lux-heading id="no-results" level="h3" size="h3">No results found for your search</lux-heading>
       <% end %>
       <article class="full-width">
-          <data-table caption="<%= @requests.data_table_heading%>"
+          <lux-data-table caption="<%= @requests.data_table_heading%>"
             :columns="[
               { 'name': 'request_type', 'display_name': 'Request', 'sortable': true},
               { 'name': 'start_date', 'datatype': 'date', 'display_name': 'Start Date', 'sortable': true},

--- a/app/views/requests/_report_list.html.erb
+++ b/app/views/requests/_report_list.html.erb
@@ -12,19 +12,19 @@
               <%= render 'request_type_filter', current_request_type_filter_label: @requests.current_request_type_filter_label,
                                                 filters: @requests.request_type_filters %>
 
-              <dropdown-menu type="links" id="department-menu" button-label="<%= @requests.current_department_filter_label %>" :menu-items="[
+              <lux-dropdown-menu type="links" id="department-menu" button-label="<%= @requests.current_department_filter_label %>" :menu-items="[
                   <% @requests.department_filter_urls.each do |key, url| %>
                     {name: '<%= key %>', component: '<%= key %>', href: '<%= url %>'},
                   <% end %>
-                ]"></dropdown-menu>
+                ]"></lux-dropdown-menu>
 
               <%= render 'supervisor_filter', supervisor_filter_urls: @requests.supervisor_filter_urls(current_staff_profile: current_staff_profile), current_supervisor_filter_label: @requests.current_supervisor_filter_label%>
 
-              <dropdown-menu type="links" id="event-format-menu" button-label="<%= @requests.current_event_format_filter_label %>" :menu-items="[
+              <lux-dropdown-menu type="links" id="event-format-menu" button-label="<%= @requests.current_event_format_filter_label %>" :menu-items="[
                   <% @requests.event_format_filter_urls.each do |key, url| %>
                     {name: '<%= key %>', component: '<%= key %>', href: '<%= url %>'},
                   <% end %>
-                ]"></dropdown-menu>
+                ]"></lux-dropdown-menu>
 
             </lux-grid-item>
             <lux-grid-item columns="sm-12 auto" class="date-filter">

--- a/app/views/requests/_report_list.html.erb
+++ b/app/views/requests/_report_list.html.erb
@@ -1,12 +1,12 @@
-<wrapper :max-width=1440>
-  <grid-container>
-    <grid-item columns="lg-12 sm-12">
-      <card size="full-width" class="search-filter-sort">
-        <card-content>
-          <grid-container>
+<lux-wrapper :max-width=1440>
+  <lux-grid-container>
+    <lux-grid-item columns="lg-12 sm-12">
+      <lux-card size="full-width" class="search-filter-sort">
+        <lux-card-content>
+          <lux-grid-container>
             <%= render 'search_requests', search_path: search_path, current_query: params[:query]%>
 
-            <grid-item columns="sm-12 auto">
+            <lux-grid-item columns="sm-12 auto">
               <%= render 'status_filter', status_filter_urls: @requests.status_filter_urls, current_status_filter_label: @requests.current_status_filter_label%>
 
               <%= render 'request_type_filter', current_request_type_filter_label: @requests.current_request_type_filter_label,
@@ -26,24 +26,24 @@
                   <% end %>
                 ]"></dropdown-menu>
 
-            </grid-item>
-            <grid-item columns="sm-12 auto" class="date-filter">
+            </lux-grid-item>
+            <lux-grid-item columns="sm-12 auto" class="date-filter">
               <%= render "date_filter", search_path: search_path, params_manager: @requests.params_manager %>
-            </grid-item>
+            </lux-grid-item>
             <%= render 'sort_menu', current_sort_label: @requests.current_sort_label, sort_urls: @requests.sort_urls%>
 
-          </grid-container>
+          </lux-grid-container>
 
           <%= render 'filter_removal', filter_removal_urls: @requests.filter_removal_urls %>
-        </card-content>
-      </card>
-    </grid-item>
-  </grid-container>
-</wrapper>
+        </lux-card-content>
+      </lux-card>
+    </lux-grid-item>
+  </lux-grid-container>
+</lux-wrapper>
 
-<wrapper :max-width=1440 class="my-request">
-<grid-container>
-    <grid-item columns="lg-12 sm-12">
+<lux-wrapper :max-width=1440 class="my-request">
+<lux-grid-container>
+    <lux-grid-item columns="lg-12 sm-12">
       <% if @requests.count == 0 %>
         <lux-heading id="no-results" level="h3" size="h3">No results found for your search</lux-heading>
       <% end %>
@@ -61,6 +61,6 @@
               { 'name': 'total', 'display_name': 'Total', 'sortable': true, datatype: 'currency'}]"
             :json-data="<%= @requests.report_json %>"/>
       </article>
-    </grid-item>
-  </grid-container>
-</wrapper>
+    </lux-grid-item>
+  </lux-grid-container>
+</lux-wrapper>

--- a/app/views/requests/_report_list.html.erb
+++ b/app/views/requests/_report_list.html.erb
@@ -45,7 +45,7 @@
 <grid-container>
     <grid-item columns="lg-12 sm-12">
       <% if @requests.count == 0 %>
-        <heading id="no-results" level="h3" size="h3">No results found for your search</heading>
+        <lux-heading id="no-results" level="h3" size="h3">No results found for your search</lux-heading>
       <% end %>
       <article class="full-width">
           <data-table caption="<%= @requests.data_table_heading%>"

--- a/app/views/requests/_request_list.html.erb
+++ b/app/views/requests/_request_list.html.erb
@@ -33,7 +33,7 @@
 <grid-container>
     <grid-item columns="lg-12 sm-12">
       <% if @requests.count == 0 %>
-        <heading id="no-results" level="h3" size="h3">No results found for your search</heading>
+        <lux-heading id="no-results" level="h3" size="h3">No results found for your search</lux-heading>
       <% end %>
       <% @requests.each do |request| %>
         <%= if request.request_type == 'TravelRequest'

--- a/app/views/requests/_request_list.html.erb
+++ b/app/views/requests/_request_list.html.erb
@@ -1,37 +1,37 @@
-<wrapper :max-width=1440>
-  <grid-container>
-    <grid-item columns="lg-12 sm-12">
-      <card size="full-width" class="search-filter-sort">
-        <card-content>
-          <grid-container>
+<lux-wrapper :max-width=1440>
+  <lux-grid-container>
+    <lux-grid-item columns="lg-12 sm-12">
+      <lux-card size="full-width" class="search-filter-sort">
+        <lux-card-content>
+          <lux-grid-container>
             <%= render 'search_requests', search_path: search_path, current_query: params[:query]%>
 
-            <grid-item columns="sm-12 auto">
+            <lux-grid-item columns="sm-12 auto">
               <% if show_status %>
                 <%= render 'status_filter', status_filter_urls: @requests.status_filter_urls, current_status_filter_label: @requests.current_status_filter_label%>
               <% end %>
 
               <%= render 'request_type_filter', current_request_type_filter_label: @requests.current_request_type_filter_label, 
                                                 filters: @requests.request_type_filters %>
-            </grid-item>
+            </lux-grid-item>
 
-            <grid-item columns="sm-12 auto" class="date-filter">
+            <lux-grid-item columns="sm-12 auto" class="date-filter">
               <%= render "date_filter", search_path: search_path, params_manager: @requests.params_manager %>
-            </grid-item>
+            </lux-grid-item>
 
             <%= render 'sort_menu', current_sort_label: @requests.current_sort_label, sort_urls: @requests.sort_urls %>
-          </grid-container>
+          </lux-grid-container>
 
           <%= render 'filter_removal', filter_removal_urls: @requests.filter_removal_urls %>
-        </card-content>
-      </card>
-    </grid-item>
-  </grid-container>
-</wrapper>
+        </lux-card-content>
+      </lux-card>
+    </lux-grid-item>
+  </lux-grid-container>
+</lux-wrapper>
 
-<wrapper :max-width=1440 class="my-request">
-<grid-container>
-    <grid-item columns="lg-12 sm-12">
+<lux-wrapper :max-width=1440 class="my-request">
+<lux-grid-container>
+    <lux-grid-item columns="lg-12 sm-12">
       <% if @requests.count == 0 %>
         <lux-heading id="no-results" level="h3" size="h3">No results found for your search</lux-heading>
       <% end %>
@@ -42,8 +42,8 @@
               render "absence_requests/#{detail_partial}", absence_request: request
             end %>
       <% end %>
-    </grid-item>
-  </grid-container>
-</wrapper>
+    </lux-grid-item>
+  </lux-grid-container>
+</lux-wrapper>
 
 <%= render 'pagination', total_pages: @requests.total_pages, requests: @requests %>

--- a/app/views/requests/_request_type_filter.html.erb
+++ b/app/views/requests/_request_type_filter.html.erb
@@ -1,4 +1,4 @@
-<dropdown-menu type="links" id="request-type-menu" button-label="<%= current_request_type_filter_label %>" :menu-items="[
+<lux-dropdown-menu type="links" id="request-type-menu" button-label="<%= current_request_type_filter_label %>" :menu-items="[
   <% filters.each do |parent_key, data| %>
     {name: '<%= parent_key %>', component: '<%= parent_key %>', href: '<%= data[:url] %>', children: [
       <% data[:children].each do |key, url| %>
@@ -6,4 +6,4 @@
       <% end %>
     ]},
   <% end %>
-]"></dropdown-menu>
+]"></lux-dropdown-menu>

--- a/app/views/requests/_search_requests.html.erb
+++ b/app/views/requests/_search_requests.html.erb
@@ -1,8 +1,8 @@
-<grid-item columns="lg-12 sm-12">
+<lux-grid-item columns="lg-12 sm-12">
   <%= form_tag(search_path, method: :get) do %>
-    <search-box>
+    <lux-search-box>
       <lux-input-text id="query" name="query" value="<%= current_query%>" :hide-label=true label="search" placeholder="Search title, notes, and creator..."></lux-input-text>
-      <input-button type="submit" id="search" variation="icon" icon="search" aria-label="submit search"></input-button>
-    </search-box>
+      <lux-input-button type="submit" id="search" variation="icon" icon="search" aria-label="submit search"></lux-input-button>
+    </lux-search-box>
   <% end %>
-</grid-item>
+</lux-grid-item>

--- a/app/views/requests/_search_requests.html.erb
+++ b/app/views/requests/_search_requests.html.erb
@@ -1,7 +1,7 @@
 <grid-item columns="lg-12 sm-12">
   <%= form_tag(search_path, method: :get) do %>
     <search-box>
-      <input-text id="query" name="query" value="<%= current_query%>" :hide-label=true label="search" placeholder="Search title, notes, and creator..."></input-text>
+      <lux-input-text id="query" name="query" value="<%= current_query%>" :hide-label=true label="search" placeholder="Search title, notes, and creator..."></lux-input-text>
       <input-button type="submit" id="search" variation="icon" icon="search" aria-label="submit search"></input-button>
     </search-box>
   <% end %>

--- a/app/views/requests/_sort_menu.html.erb
+++ b/app/views/requests/_sort_menu.html.erb
@@ -1,7 +1,7 @@
-<grid-item columns="sm-12 auto">
-  <dropdown-menu type="links" id="sort-menu" button-label="<%= current_sort_label %>" :menu-items="[
+<lux-grid-item columns="sm-12 auto">
+  <lux-dropdown-menu type="links" id="sort-menu" button-label="<%= current_sort_label %>" :menu-items="[
     <% sort_urls.each do |key, url| %>
       {name: '<%= key %>', component: '<%= key %>', href: '<%= url %>'},
     <% end %>
-  ]"></dropdown-menu>
-</grid-item>
+  ]"></lux-dropdown-menu>
+</lux-grid-item>

--- a/app/views/requests/_status_filter.html.erb
+++ b/app/views/requests/_status_filter.html.erb
@@ -1,5 +1,5 @@
-<dropdown-menu type="links" id="status-menu" button-label="<%= current_status_filter_label %>" :menu-items="[
+<lux-dropdown-menu type="links" id="status-menu" button-label="<%= current_status_filter_label %>" :menu-items="[
   <% status_filter_urls.each do |key, url| %>
     {name: '<%= key %>', component: '<%= key %>', href: '<%= url %>'},
   <% end %>
-]"></dropdown-menu>
+]"></lux-dropdown-menu>

--- a/app/views/requests/_supervisor_filter.html.erb
+++ b/app/views/requests/_supervisor_filter.html.erb
@@ -1,9 +1,9 @@
 <% if supervisor_filter_urls.count > 0 %>
-<input-select name="supervisor_filter" value="<%= current_supervisor_filter_label %>" onchange="location.href = this.children[0].value; //jump to link location on select" 
+<lux-input-select name="supervisor_filter" value="<%= current_supervisor_filter_label %>" onchange="location.href = this.children[0].value; //jump to link location on select" 
  id="supervisor-menu" :options="[
   {label: '<%= current_supervisor_filter_label %>', value: '<%= current_supervisor_filter_label %>'},
   <% supervisor_filter_urls.each do |key, url| %>
     {label: '<%= key %>', value: '<%= url %>'},
   <% end %>
-]"></input-select>
+]"></lux-input-select>
 <% end %>

--- a/app/views/requests/my_approval_requests.html.erb
+++ b/app/views/requests/my_approval_requests.html.erb
@@ -1,7 +1,7 @@
 <wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="lg-5 sm-12">
-      <heading level="h1" size="h2">Requests Awaiting My Approval</heading>
+      <lux-heading level="h1" size="h2">Requests Awaiting My Approval</lux-heading>
     </grid-item>
   </grid-container>
 </wrapper>

--- a/app/views/requests/my_approval_requests.html.erb
+++ b/app/views/requests/my_approval_requests.html.erb
@@ -1,8 +1,8 @@
-<wrapper :max-width=1440>
-  <grid-container>
-    <grid-item columns="lg-5 sm-12">
+<lux-wrapper :max-width=1440>
+  <lux-grid-container>
+    <lux-grid-item columns="lg-5 sm-12">
       <lux-heading level="h1" size="h2">Requests Awaiting My Approval</lux-heading>
-    </grid-item>
-  </grid-container>
-</wrapper>
+    </lux-grid-item>
+  </lux-grid-container>
+</lux-wrapper>
 <%=  render 'request_list', show_status: false, search_path: my_approval_requests_path, detail_partial: 'review_detail' %>

--- a/app/views/requests/my_requests.html.erb
+++ b/app/views/requests/my_requests.html.erb
@@ -1,7 +1,7 @@
 <wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="md-5 sm-12">
-      <heading level="h1" size="h2">My Requests</heading>
+      <lux-heading level="h1" size="h2">My Requests</lux-heading>
     </grid-item>
     <grid-item columns="md-7 sm-12 auto" :offset=true>
       <% if Rails.configuration.show_absence_button %>

--- a/app/views/requests/my_requests.html.erb
+++ b/app/views/requests/my_requests.html.erb
@@ -5,9 +5,9 @@
     </grid-item>
     <grid-item columns="md-7 sm-12 auto" :offset=true>
       <% if Rails.configuration.show_absence_button %>
-      <hyperlink href="<%= new_absence_request_path %>" variation="button solid">New absence request</hyperlink>
+      <lux-hyperlink href="<%= new_absence_request_path %>" variation="button solid">New absence request</lux-hyperlink>
       <% end %>
-      <hyperlink href="<%= new_travel_request_path %>" variation="button solid">New travel request</hyperlink>
+      <lux-hyperlink href="<%= new_travel_request_path %>" variation="button solid">New travel request</lux-hyperlink>
     </grid-item>
   </grid-container>
 </wrapper>

--- a/app/views/requests/my_requests.html.erb
+++ b/app/views/requests/my_requests.html.erb
@@ -1,14 +1,14 @@
-<wrapper :max-width=1440>
-  <grid-container>
-    <grid-item columns="md-5 sm-12">
+<lux-wrapper :max-width=1440>
+  <lux-grid-container>
+    <lux-grid-item columns="md-5 sm-12">
       <lux-heading level="h1" size="h2">My Requests</lux-heading>
-    </grid-item>
-    <grid-item columns="md-7 sm-12 auto" :offset=true>
+    </lux-grid-item>
+    <lux-grid-item columns="md-7 sm-12 auto" :offset=true>
       <% if Rails.configuration.show_absence_button %>
       <lux-hyperlink href="<%= new_absence_request_path %>" variation="button solid">New absence request</lux-hyperlink>
       <% end %>
       <lux-hyperlink href="<%= new_travel_request_path %>" variation="button solid">New travel request</lux-hyperlink>
-    </grid-item>
-  </grid-container>
-</wrapper>
+    </lux-grid-item>
+  </lux-grid-container>
+</lux-wrapper>
 <%=  render 'request_list', show_status: true, search_path: my_requests_path, detail_partial: 'index_detail' %>

--- a/app/views/requests/reports.html.erb
+++ b/app/views/requests/reports.html.erb
@@ -1,7 +1,7 @@
 <wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="lg-5 sm-12">
-      <heading level="h1" size="h2">Reports</heading>
+      <lux-heading level="h1" size="h2">Reports</lux-heading>
     </grid-item>
   </grid-container>
 </wrapper>

--- a/app/views/requests/reports.html.erb
+++ b/app/views/requests/reports.html.erb
@@ -1,8 +1,8 @@
-<wrapper :max-width=1440>
-  <grid-container>
-    <grid-item columns="lg-5 sm-12">
+<lux-wrapper :max-width=1440>
+  <lux-grid-container>
+    <lux-grid-item columns="lg-5 sm-12">
       <lux-heading level="h1" size="h2">Reports</lux-heading>
-    </grid-item>
-  </grid-container>
-</wrapper>
+    </lux-grid-item>
+  </lux-grid-container>
+</lux-wrapper>
 <%=  render 'report_list', show_status: true, search_path: reports_path, detail_partial: 'report_detail' %>

--- a/app/views/shared/_cancel_button.html.erb
+++ b/app/views/shared/_cancel_button.html.erb
@@ -1,5 +1,5 @@
 <% if request.can_cancel?(agent: current_staff_profile) %>
   <%= form_with(model: request, local: true, url: path, method: :put, class: 'form-button') do |form| %>
-    <input-button type="submit" variation="solid" name="cancel">Cancel the Request</input-button>
+    <lux-input-button type="submit" variation="solid" name="cancel">Cancel the Request</lux-input-button>
   <% end %>
 <% end %>

--- a/app/views/shared/_comment_button.html.erb
+++ b/app/views/shared/_comment_button.html.erb
@@ -1,3 +1,3 @@
 <% if request.only_creator_or_supervisor?(agent: current_staff_profile) %>
-  <hyperlink href="<%= path %>" variation="button solid">Comment</hyperlink>
+  <lux-hyperlink href="<%= path %>" variation="button solid">Comment</lux-hyperlink>
 <% end %>

--- a/app/views/shared/_edit_button.html.erb
+++ b/app/views/shared/_edit_button.html.erb
@@ -1,3 +1,3 @@
 <% if request.can_edit?(agent: current_staff_profile) %>
-  <hyperlink href="<%= path %>" variation="button solid">Edit</hyperlink>
+  <lux-hyperlink href="<%= path %>" variation="button solid">Edit</lux-hyperlink>
 <% end %>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -4,7 +4,7 @@
        lux_status = 'warning' if lux_status == :alert
        lux_status = 'info' if lux_status == :notice
        if flash[type] %>
-        <alert status="<%= lux_status %>" dismissible><%= flash[type] %></alert>
+        <lux-alert status="<%= lux_status %>" dismissible><%= flash[type] %></lux-alert>
     <% end %>
   <% end %>
 </div>

--- a/app/views/travel_requests/_errors.html.erb
+++ b/app/views/travel_requests/_errors.html.erb
@@ -1,5 +1,5 @@
-<grid-item columns="lg-12">
-  <alert status="error">
+<lux-grid-item columns="lg-12">
+  <lux-alert status="error">
     <h2><%= pluralize(request_change_set.errors.count, "error") %> prohibited this request from being saved:</h2>
 
     <ul>
@@ -7,5 +7,5 @@
       <li><%= message %></li>
     <% end %>
     </ul>
-  </alert>
-</grid-item>
+  </lux-alert>
+</lux-grid-item>

--- a/app/views/travel_requests/_event_date_modal.erb
+++ b/app/views/travel_requests/_event_date_modal.erb
@@ -6,6 +6,6 @@
   
 </div>
 <div class="modal-footer">
-  <input-button variation="solid" size="small">Continue</input-button>
-  <input-button variation="outline" size="small">Cancel</input-button>
+  <lux-input-button variation="solid" size="small">Continue</lux-input-button>
+  <lux-input-button variation="outline" size="small">Cancel</lux-input-button>
 </div>

--- a/app/views/travel_requests/_expense_card.html.erb
+++ b/app/views/travel_requests/_expense_card.html.erb
@@ -1,11 +1,11 @@
 <card size="full-width">
   <card-content>
-    <data-table
+    <lux-data-table
       caption="Anticipated Expenses"
       :columns="<%= estimate_fields_json %>"
       :json-data="<%= estimates_json %>"
       class="anticipated-expenses estimates"
     >
-    </data-table>
+    </lux-data-table>
   </card-content>
 </card>

--- a/app/views/travel_requests/_expense_card.html.erb
+++ b/app/views/travel_requests/_expense_card.html.erb
@@ -1,5 +1,5 @@
-<card size="full-width">
-  <card-content>
+<lux-card size="full-width">
+  <lux-card-content>
     <lux-data-table
       caption="Anticipated Expenses"
       :columns="<%= estimate_fields_json %>"
@@ -7,5 +7,5 @@
       class="anticipated-expenses estimates"
     >
     </lux-data-table>
-  </card-content>
-</card>
+  </lux-card-content>
+</lux-card>

--- a/app/views/travel_requests/_form.html.erb
+++ b/app/views/travel_requests/_form.html.erb
@@ -3,11 +3,11 @@
 <% if request_change_set.errors.any? %>
   <%=render 'errors', request_change_set: request_change_set %>
 <% end %>
-<grid-container>
-  <grid-item columns="lg-12 sm-12">
-    <alert status="info" class="tip-card">Please make sure your request complies with <lux-hyperlink href="https://library.princeton.edu/staff/ofa/finance-and-budget/travel" target="_blank">the official Princeton University Library Travel Policy</lux-hyperlink> before submitting this form.</alert>
-  </grid-item>
-  <grid-item columns="lg-3 md-6 sm-12">
+<lux-grid-container>
+  <lux-grid-item columns="lg-12 sm-12">
+    <lux-alert status="info" class="tip-card">Please make sure your request complies with <lux-hyperlink href="https://library.princeton.edu/staff/ofa/finance-and-budget/travel" target="_blank">the official Princeton University Library Travel Policy</lux-hyperlink> before submitting this form.</lux-alert>
+  </lux-grid-item>
+  <lux-grid-item columns="lg-3 md-6 sm-12">
     <%# # TODO This should really be creating fields like: params[:travel_request][:event_requests]{:id, :recurring_event_id, :start_date, :end_date, :location, :url}
         # wanted to see the validations show up on the screen, but did not want to put any effort into the form %>
     <%= form.fields_for :event_requests do |ff| %>
@@ -19,10 +19,10 @@
           :items="<%= request_change_set.recurring_event_list %>"
           ></event-title-input-wrapper>
 
-        <input-select label="Event Format" name="travel_request[virtual_event]"
+        <lux-input-select label="Event Format" name="travel_request[virtual_event]"
           id="travel_request_event_format" width="expand"
           value="<%= request_change_set.virtual_event %>"
-          :options="<%= request_change_set.event_format_options %>"></input-select>
+          :options="<%= request_change_set.event_format_options %>"></lux-input-select>
 
         <!--
           Travel Request Date Pickers -->
@@ -41,22 +41,22 @@
         </travel-request-date-pickers>
 
     <% end %>
-  </grid-item>
-  <grid-item columns="lg-3 md-6 sm-12">
+  </lux-grid-item>
+  <lux-grid-item columns="lg-3 md-6 sm-12">
       <lux-input-text label="Location" type="text" name="travel_request[event_requests_attributes][0][location]" required
               id="travel_request_event_requests_attributes_0_location" width="expand" value="<%= request_change_set.model.event_requests[0].location %>">
         </lux-input-text>
-      <input-select label="Participation" name="travel_request[participation]"
+      <lux-input-select label="Participation" name="travel_request[participation]"
           id="travel_request_participation" width="expand"
           value="<%= request_change_set.participation %>"
-          :options="<%= request_change_set.participation_options %>" required></input-select>
+          :options="<%= request_change_set.participation_options %>" required></lux-input-select>
 
-      <input-text label="Purpose" id="travel_request_purpose" width="expand"
+      <lux-input-text label="Purpose" id="travel_request_purpose" width="expand"
         name="travel_request[purpose]" value="<%= request_change_set.purpose %>"
         helper="Specify the reason this trip is necessary for your job"
-        required></input-text>
-  </grid-item>
-  <grid-item columns="lg-6 sm-12">
+        required></lux-input-text>
+  </lux-grid-item>
+  <lux-grid-item columns="lg-6 sm-12">
     <% if request_change_set.existing_notes.any? %>
       <lux-heading level="h3" size="h5">
         Notes
@@ -69,11 +69,11 @@
     <lux-input-text id="travel_request_notes_content" name="travel_request[notes][][content]"
       helper="Additional information that would help the approver understand the details of the trip (request for time off, desire to stay additional nights, etc.)"
       label="Notes to Approvers (optional)" :maxlength="9999" width="expand" type="textarea"></lux-input-text>
-  </grid-item>
-  <grid-item columns="lg-12 sm-12">
+  </lux-grid-item>
+  <lux-grid-item columns="lg-12 sm-12">
     <lux-heading level="h2" size="h3">Anticipated Expenses</lux-heading>
-  </grid-item>
-</grid-container>
+  </lux-grid-item>
+</lux-grid-container>
   <!--
     Travel Estimate Form -->
   <travel-estimate-form
@@ -83,14 +83,14 @@
     :cost_types="<%= request_change_set.estimate_cost_options %>">
   </travel-estimate-form>
 
-<grid-container>
-  <grid-item columns="lg-12 sm-12">
+<lux-grid-container>
+  <lux-grid-item columns="lg-12 sm-12">
   <lux-text-style variation="emphasis">This request will be submitted to: <%= request_change_set.supervisor %></lux-text-style>
-  </grid-item>
-  <grid-item columns="lg-3 sm-12 auto">
+  </lux-grid-item>
+  <lux-grid-item columns="lg-3 sm-12 auto">
     <div class="actions">
       <travel-request-button event-title="<%= request_change_set.event_name %>"></travel-request-button>
     </div>
-  </grid-item>
-</grid-container>
+  </lux-grid-item>
+</lux-grid-container>
 <% end %>

--- a/app/views/travel_requests/_form.html.erb
+++ b/app/views/travel_requests/_form.html.erb
@@ -43,9 +43,9 @@
     <% end %>
   </grid-item>
   <grid-item columns="lg-3 md-6 sm-12">
-      <input-text label="Location" type="text" name="travel_request[event_requests_attributes][0][location]" required
+      <lux-input-text label="Location" type="text" name="travel_request[event_requests_attributes][0][location]" required
               id="travel_request_event_requests_attributes_0_location" width="expand" value="<%= request_change_set.model.event_requests[0].location %>">
-        </input-text>
+        </lux-input-text>
       <input-select label="Participation" name="travel_request[participation]"
           id="travel_request_participation" width="expand"
           value="<%= request_change_set.participation %>"
@@ -66,9 +66,9 @@
             request_change_set.existing_notes, as: :note %>
       </ul>
     <% end %>
-    <input-text id="travel_request_notes_content" name="travel_request[notes][][content]"
+    <lux-input-text id="travel_request_notes_content" name="travel_request[notes][][content]"
       helper="Additional information that would help the approver understand the details of the trip (request for time off, desire to stay additional nights, etc.)"
-      label="Notes to Approvers (optional)" :maxlength="9999" width="expand" type="textarea"></input-text>
+      label="Notes to Approvers (optional)" :maxlength="9999" width="expand" type="textarea"></lux-input-text>
   </grid-item>
   <grid-item columns="lg-12 sm-12">
     <heading level="h2" size="h3">Anticipated Expenses</heading>

--- a/app/views/travel_requests/_form.html.erb
+++ b/app/views/travel_requests/_form.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 <grid-container>
   <grid-item columns="lg-12 sm-12">
-    <alert status="info" class="tip-card">Please make sure your request complies with <hyperlink href="https://library.princeton.edu/staff/ofa/finance-and-budget/travel" target="_blank">the official Princeton University Library Travel Policy</hyperlink> before submitting this form.</alert>
+    <alert status="info" class="tip-card">Please make sure your request complies with <lux-hyperlink href="https://library.princeton.edu/staff/ofa/finance-and-budget/travel" target="_blank">the official Princeton University Library Travel Policy</lux-hyperlink> before submitting this form.</alert>
   </grid-item>
   <grid-item columns="lg-3 md-6 sm-12">
     <%# # TODO This should really be creating fields like: params[:travel_request][:event_requests]{:id, :recurring_event_id, :start_date, :end_date, :location, :url}

--- a/app/views/travel_requests/_form.html.erb
+++ b/app/views/travel_requests/_form.html.erb
@@ -58,9 +58,9 @@
   </grid-item>
   <grid-item columns="lg-6 sm-12">
     <% if request_change_set.existing_notes.any? %>
-      <heading level="h3" size="h5">
+      <lux-heading level="h3" size="h5">
         Notes
-      </heading>
+      </lux-heading>
       <ul class="notes">
           <%= render partial: "shared/request_note", collection:
             request_change_set.existing_notes, as: :note %>
@@ -71,7 +71,7 @@
       label="Notes to Approvers (optional)" :maxlength="9999" width="expand" type="textarea"></lux-input-text>
   </grid-item>
   <grid-item columns="lg-12 sm-12">
-    <heading level="h2" size="h3">Anticipated Expenses</heading>
+    <lux-heading level="h2" size="h3">Anticipated Expenses</lux-heading>
   </grid-item>
 </grid-container>
   <!--
@@ -85,7 +85,7 @@
 
 <grid-container>
   <grid-item columns="lg-12 sm-12">
-  <text-style variation="emphasis">This request will be submitted to: <%= request_change_set.supervisor %></text-style>
+  <lux-text-style variation="emphasis">This request will be submitted to: <%= request_change_set.supervisor %></lux-text-style>
   </grid-item>
   <grid-item columns="lg-3 sm-12 auto">
     <div class="actions">

--- a/app/views/travel_requests/_index_detail.html.erb
+++ b/app/views/travel_requests/_index_detail.html.erb
@@ -7,7 +7,7 @@
       ><<%= travel_request.travel_category_icon %> /></lux-icon-base>
     </card-media>
     <card-header>
-      <lux-heading level="h2" size="h3"><hyperlink href="<%= travel_request_path(travel_request.to_model)%>" class="event-title"><%= travel_request.event_title %></hyperlink></lux-heading>
+      <lux-heading level="h2" size="h3"><lux-hyperlink href="<%= travel_request_path(travel_request.to_model)%>" class="event-title"><%= travel_request.event_title %></lux-hyperlink></lux-heading>
       <lux-text-style class="event-dates"><%= travel_request.formatted_full_start_date %> to <%= travel_request.formatted_full_end_date %></lux-text-style>
     </card-header>
     <card-content class="right-align">

--- a/app/views/travel_requests/_index_detail.html.erb
+++ b/app/views/travel_requests/_index_detail.html.erb
@@ -7,8 +7,8 @@
       ><<%= travel_request.travel_category_icon %> /></lux-icon-base>
     </card-media>
     <card-header>
-      <heading level="h2" size="h3"><hyperlink href="<%= travel_request_path(travel_request.to_model)%>" class="event-title"><%= travel_request.event_title %></hyperlink></heading>
-      <text-style class="event-dates"><%= travel_request.formatted_full_start_date %> to <%= travel_request.formatted_full_end_date %></text-style>
+      <lux-heading level="h2" size="h3"><hyperlink href="<%= travel_request_path(travel_request.to_model)%>" class="event-title"><%= travel_request.event_title %></hyperlink></lux-heading>
+      <lux-text-style class="event-dates"><%= travel_request.formatted_full_start_date %> to <%= travel_request.formatted_full_end_date %></lux-text-style>
     </card-header>
     <card-content class="right-align">
       <tag type="tag" :tag-items="[
@@ -16,6 +16,6 @@
         ]"
         horizontal="end"
         size="small"></tag>
-      <text-style type="span" variation="small"><%= travel_request.latest_status_date %></text-style>
+      <lux-text-style type="span" variation="small"><%= travel_request.latest_status_date %></lux-text-style>
     </card-content>
   </card>

--- a/app/views/travel_requests/_index_detail.html.erb
+++ b/app/views/travel_requests/_index_detail.html.erb
@@ -1,21 +1,21 @@
-  <card id="<%= travel_request.id %>" size="full-width">
-    <card-media>
+  <lux-card id="<%= travel_request.id %>" size="full-width">
+    <lux-card-media>
       <lux-icon-base
         width="50"
         height="50"
         icon-color="rgb(65, 70, 78)"
       ><<%= travel_request.travel_category_icon %> /></lux-icon-base>
-    </card-media>
-    <card-header>
+    </lux-card-media>
+    <lux-card-header>
       <lux-heading level="h2" size="h3"><lux-hyperlink href="<%= travel_request_path(travel_request.to_model)%>" class="event-title"><%= travel_request.event_title %></lux-hyperlink></lux-heading>
       <lux-text-style class="event-dates"><%= travel_request.formatted_full_start_date %> to <%= travel_request.formatted_full_end_date %></lux-text-style>
-    </card-header>
-    <card-content class="right-align">
+    </lux-card-header>
+    <lux-card-content class="right-align">
       <tag type="tag" :tag-items="[
         {name: '<%= travel_request.latest_status %>', color: '<%= travel_request.status_color %>'}
         ]"
         horizontal="end"
         size="small"></tag>
       <lux-text-style type="span" variation="small"><%= travel_request.latest_status_date %></lux-text-style>
-    </card-content>
-  </card>
+    </lux-card-content>
+  </lux-card>

--- a/app/views/travel_requests/_index_detail.html.erb
+++ b/app/views/travel_requests/_index_detail.html.erb
@@ -11,11 +11,11 @@
       <lux-text-style class="event-dates"><%= travel_request.formatted_full_start_date %> to <%= travel_request.formatted_full_end_date %></lux-text-style>
     </lux-card-header>
     <lux-card-content class="right-align">
-      <tag type="tag" :tag-items="[
+      <lux-tag type="tag" :tag-items="[
         {name: '<%= travel_request.latest_status %>', color: '<%= travel_request.status_color %>'}
         ]"
         horizontal="end"
-        size="small"></tag>
+        size="small"></lux-tag>
       <lux-text-style type="span" variation="small"><%= travel_request.latest_status_date %></lux-text-style>
     </lux-card-content>
   </lux-card>

--- a/app/views/travel_requests/_notes_card.html.erb
+++ b/app/views/travel_requests/_notes_card.html.erb
@@ -1,5 +1,5 @@
-<card size="full-width">
-  <card-content>
+<lux-card size="full-width">
+  <lux-card-content>
       <lux-heading level="h3" size="h3">
           History
         </lux-heading>
@@ -10,14 +10,14 @@
 
   <% if render_edit %>
     <lux-input-text id="travel_request_notes_content" name="travel_request[notes][content]" label="Notes" type="textarea" :maxlength=9999 rows="10" width="expand" value="<%= request.current_note%>" ></lux-input-text>
-    <input-autocomplete
+    <lux-autocomplete-input
       id="travel_request_new_event_id"
       name="travel_request[new_event][id]"
       label="New Event Name"
       default-value=""
       :items="<%= TravelRequestChangeSet.recurring_event_list %>"
       autocomplete="off"
-    ></input-autocomplete>
+    ></lux-autocomplete-input>
   <% end %>
-  </card-content>
-</card>
+  </lux-card-content>
+</lux-card>

--- a/app/views/travel_requests/_notes_card.html.erb
+++ b/app/views/travel_requests/_notes_card.html.erb
@@ -9,7 +9,7 @@
       </ul>
 
   <% if render_edit %>
-    <input-text id="travel_request_notes_content" name="travel_request[notes][content]" label="Notes" type="textarea" :maxlength=9999 rows="10" width="expand" value="<%= request.current_note%>" ></input-text>
+    <lux-input-text id="travel_request_notes_content" name="travel_request[notes][content]" label="Notes" type="textarea" :maxlength=9999 rows="10" width="expand" value="<%= request.current_note%>" ></lux-input-text>
     <input-autocomplete
       id="travel_request_new_event_id"
       name="travel_request[new_event][id]"

--- a/app/views/travel_requests/_notes_card.html.erb
+++ b/app/views/travel_requests/_notes_card.html.erb
@@ -1,8 +1,8 @@
 <card size="full-width">
   <card-content>
-      <heading level="h3" size="h3">
+      <lux-heading level="h3" size="h3">
           History
-        </heading>
+        </lux-heading>
         <ul class="notes">
           <%= render partial: "shared/request_note", collection:
             request.notes_and_changes, as: :note %>

--- a/app/views/travel_requests/_others_card.html.erb
+++ b/app/views/travel_requests/_others_card.html.erb
@@ -1,8 +1,8 @@
 <card size="full-width">
   <card-content>
-    <heading level="h3" size="h5">
+    <lux-heading level="h3" size="h5">
       Others who requested to go
-    </heading>
+    </lux-heading>
     <ul class="staff">
       <%= render partial: "other_staff", collection: event_attendees, as: :staff %>
     </ul>

--- a/app/views/travel_requests/_others_card.html.erb
+++ b/app/views/travel_requests/_others_card.html.erb
@@ -1,10 +1,10 @@
-<card size="full-width">
-  <card-content>
+<lux-card size="full-width">
+  <lux-card-content>
     <lux-heading level="h3" size="h5">
       Others who requested to go
     </lux-heading>
     <ul class="staff">
       <%= render partial: "other_staff", collection: event_attendees, as: :staff %>
     </ul>
-  </card-content>
-</card>
+  </lux-card-content>
+</lux-card>

--- a/app/views/travel_requests/_report_detail.html.erb
+++ b/app/views/travel_requests/_report_detail.html.erb
@@ -1,21 +1,21 @@
-  <card id="<%= travel_request.id %>" size="full-width">
-    <card-media>
+  <lux-card id="<%= travel_request.id %>" size="full-width">
+    <lux-card-media>
       <lux-icon-base
         width="50"
         height="50"
         icon-color="rgb(65, 70, 78)"
       ><<%= travel_request.travel_category_icon %> /></lux-icon-base>
-    </card-media>
-    <card-header>
+    </lux-card-media>
+    <lux-card-header>
       <lux-heading level="h2" size="h3"><lux-hyperlink href="<%= review_travel_request_path(travel_request.to_model)%>"><%= travel_request.creator %> - <%= travel_request.event_title_brief %></lux-hyperlink></lux-heading>
       <lux-text-style><%= travel_request.formatted_full_start_date %> to <%= travel_request.formatted_full_end_date %></lux-text-style>
-    </card-header>
-    <card-content>
-      <tag type="tag" :tag-items="[
+    </lux-card-header>
+    <lux-card-content>
+      <lux-tag type="tag" :tag-items="[
         {name: '<%= travel_request.latest_status %>', color: '<%= travel_request.status_color %>'}
         ]"
         horizontal="end"
-        size="small"></tag>
+        size="small"></lux-tag>
       <lux-text-style type="span" variation="small"><%= travel_request.latest_status_date %></lux-text-style>
-    </card-content>
-  </card>
+    </lux-card-content>
+  </lux-card>

--- a/app/views/travel_requests/_report_detail.html.erb
+++ b/app/views/travel_requests/_report_detail.html.erb
@@ -7,7 +7,7 @@
       ><<%= travel_request.travel_category_icon %> /></lux-icon-base>
     </card-media>
     <card-header>
-      <lux-heading level="h2" size="h3"><hyperlink href="<%= review_travel_request_path(travel_request.to_model)%>"><%= travel_request.creator %> - <%= travel_request.event_title_brief %></hyperlink></lux-heading>
+      <lux-heading level="h2" size="h3"><lux-hyperlink href="<%= review_travel_request_path(travel_request.to_model)%>"><%= travel_request.creator %> - <%= travel_request.event_title_brief %></lux-hyperlink></lux-heading>
       <lux-text-style><%= travel_request.formatted_full_start_date %> to <%= travel_request.formatted_full_end_date %></lux-text-style>
     </card-header>
     <card-content>

--- a/app/views/travel_requests/_report_detail.html.erb
+++ b/app/views/travel_requests/_report_detail.html.erb
@@ -7,8 +7,8 @@
       ><<%= travel_request.travel_category_icon %> /></lux-icon-base>
     </card-media>
     <card-header>
-      <heading level="h2" size="h3"><hyperlink href="<%= review_travel_request_path(travel_request.to_model)%>"><%= travel_request.creator %> - <%= travel_request.event_title_brief %></hyperlink></heading>
-      <text-style><%= travel_request.formatted_full_start_date %> to <%= travel_request.formatted_full_end_date %></text-style>
+      <lux-heading level="h2" size="h3"><hyperlink href="<%= review_travel_request_path(travel_request.to_model)%>"><%= travel_request.creator %> - <%= travel_request.event_title_brief %></hyperlink></lux-heading>
+      <lux-text-style><%= travel_request.formatted_full_start_date %> to <%= travel_request.formatted_full_end_date %></lux-text-style>
     </card-header>
     <card-content>
       <tag type="tag" :tag-items="[
@@ -16,6 +16,6 @@
         ]"
         horizontal="end"
         size="small"></tag>
-      <text-style type="span" variation="small"><%= travel_request.latest_status_date %></text-style>
+      <lux-text-style type="span" variation="small"><%= travel_request.latest_status_date %></lux-text-style>
     </card-content>
   </card>

--- a/app/views/travel_requests/_review_detail.html.erb
+++ b/app/views/travel_requests/_review_detail.html.erb
@@ -1,26 +1,26 @@
-  <card id="<%= travel_request.id %>" size="full-width">
-    <card-media>
+  <lux-card id="<%= travel_request.id %>" size="full-width">
+    <lux-card-media>
       <lux-icon-base
         width="50"
         height="50"
         icon-color="rgb(65, 70, 78)"
       ><<%= travel_request.travel_category_icon %> /></lux-icon-base>
-    </card-media>
-    <card-header>
+    </lux-card-media>
+    <lux-card-header>
       <lux-heading level="h2" size="h3"><lux-hyperlink href="<%= review_travel_request_path(travel_request.to_model)%>"><%= travel_request.creator %> - <span class="event-title"><%= travel_request.event_title %></span></lux-hyperlink></lux-heading>
       <lux-text-style class="event-dates"><%= travel_request.formatted_full_start_date %> to <%= travel_request.formatted_full_end_date %></lux-text-style>
-    </card-header>
-    <card-content>
-      <tag type="tag" :tag-items="[
+    </lux-card-header>
+    <lux-card-content>
+      <lux-tag type="tag" :tag-items="[
         {name: '<%= travel_request.latest_status %>', color: '<%= travel_request.status_color %>'}]"
         horizontal="end"
-        size="small"></tag>
+        size="small"></lux-tag>
       <% if travel_request.event_format && travel_request.event_format_color %>
         <tag type="tag" :tag-items="[
           {name: '<%= travel_request.event_format %>', color: '<%= travel_request.event_format_color %>'}]"
         horizontal="end"
-        size="small"></tag>
+        size="small"></lux-tag>
       <% end %>
       <lux-text-style type="span" variation="small"><%= travel_request.latest_status_date %></lux-text-style>
-    </card-content>
-  </card>
+    </lux-card-content>
+  </lux-card>

--- a/app/views/travel_requests/_review_detail.html.erb
+++ b/app/views/travel_requests/_review_detail.html.erb
@@ -7,7 +7,7 @@
       ><<%= travel_request.travel_category_icon %> /></lux-icon-base>
     </card-media>
     <card-header>
-      <lux-heading level="h2" size="h3"><hyperlink href="<%= review_travel_request_path(travel_request.to_model)%>"><%= travel_request.creator %> - <span class="event-title"><%= travel_request.event_title %></span></hyperlink></lux-heading>
+      <lux-heading level="h2" size="h3"><lux-hyperlink href="<%= review_travel_request_path(travel_request.to_model)%>"><%= travel_request.creator %> - <span class="event-title"><%= travel_request.event_title %></span></lux-hyperlink></lux-heading>
       <lux-text-style class="event-dates"><%= travel_request.formatted_full_start_date %> to <%= travel_request.formatted_full_end_date %></lux-text-style>
     </card-header>
     <card-content>

--- a/app/views/travel_requests/_review_detail.html.erb
+++ b/app/views/travel_requests/_review_detail.html.erb
@@ -16,7 +16,7 @@
         horizontal="end"
         size="small"></lux-tag>
       <% if travel_request.event_format && travel_request.event_format_color %>
-        <tag type="tag" :tag-items="[
+        <lux-tag type="tag" :tag-items="[
           {name: '<%= travel_request.event_format %>', color: '<%= travel_request.event_format_color %>'}]"
         horizontal="end"
         size="small"></lux-tag>

--- a/app/views/travel_requests/_review_detail.html.erb
+++ b/app/views/travel_requests/_review_detail.html.erb
@@ -7,8 +7,8 @@
       ><<%= travel_request.travel_category_icon %> /></lux-icon-base>
     </card-media>
     <card-header>
-      <heading level="h2" size="h3"><hyperlink href="<%= review_travel_request_path(travel_request.to_model)%>"><%= travel_request.creator %> - <span class="event-title"><%= travel_request.event_title %></span></hyperlink></heading>
-      <text-style class="event-dates"><%= travel_request.formatted_full_start_date %> to <%= travel_request.formatted_full_end_date %></text-style>
+      <lux-heading level="h2" size="h3"><hyperlink href="<%= review_travel_request_path(travel_request.to_model)%>"><%= travel_request.creator %> - <span class="event-title"><%= travel_request.event_title %></span></hyperlink></lux-heading>
+      <lux-text-style class="event-dates"><%= travel_request.formatted_full_start_date %> to <%= travel_request.formatted_full_end_date %></lux-text-style>
     </card-header>
     <card-content>
       <tag type="tag" :tag-items="[
@@ -21,6 +21,6 @@
         horizontal="end"
         size="small"></tag>
       <% end %>
-      <text-style type="span" variation="small"><%= travel_request.latest_status_date %></text-style>
+      <lux-text-style type="span" variation="small"><%= travel_request.latest_status_date %></lux-text-style>
     </card-content>
   </card>

--- a/app/views/travel_requests/_review_form.html.erb
+++ b/app/views/travel_requests/_review_form.html.erb
@@ -14,24 +14,24 @@
       <grid-item columns="lg-4 sm-12" order="order-lg-2">
         <card size="full-width">
           <card-content>
-            <heading level="h3" size="h5">
+            <lux-heading level="h3" size="h5">
               Level of Participation
-            </heading>
+            </lux-heading>
             <text-style variation="default"
               ><%= request_change_set.participation.blank? ? 'Unknown' :
               request_change_set.participation.humanize %></text-style
             >
-            <heading level="h3" size="h5">
+            <lux-heading level="h3" size="h5">
               Purpose
-            </heading>
+            </lux-heading>
             <text-style variation="default"
               ><%= request_change_set.purpose.blank? ? 'Unknown' : request_change_set.purpose
               %></text-style
             >
             <% if current_staff_profile.department_head? && action == "review" %>
-              <heading level="h3" size="h5">
+              <lux-heading level="h3" size="h5">
                 Travel Category
-              </heading>
+              </lux-heading>
               <input-select label="Travel Category" name="travel_request[travel_category]"
                   id="travel_request_travel_category" width="expand" hide-label
                   value="<%= request_change_set.travel_category %>"

--- a/app/views/travel_requests/_review_form.html.erb
+++ b/app/views/travel_requests/_review_form.html.erb
@@ -1,73 +1,73 @@
 <div >
 
   <%= form_with(model: request_change_set.model, local: true, url: decide_travel_request_path(request_change_set.model), method: :put) do |form| %>
-    <grid-container>
+    <lux-grid-container>
       <% if request_change_set.errors.any? %>
         <%=render 'errors', request_change_set: request_change_set %>
       <% end %>
 
 
-      <grid-item columns="lg-12 sm-12" order="order-lg-1">
+      <lux-grid-item columns="lg-12 sm-12" order="order-lg-1">
             <%= render 'title_card', request: request_change_set %>
-      </grid-item>
+      </lux-grid-item>
 
-      <grid-item columns="lg-4 sm-12" order="order-lg-2">
-        <card size="full-width">
-          <card-content>
+      <lux-grid-item columns="lg-4 sm-12" order="order-lg-2">
+        <lux-card size="full-width">
+          <lux-card-content>
             <lux-heading level="h3" size="h5">
               Level of Participation
             </lux-heading>
             <text-style variation="default"
               ><%= request_change_set.participation.blank? ? 'Unknown' :
-              request_change_set.participation.humanize %></text-style
+              request_change_set.participation.humanize %></lux-text-style
             >
             <lux-heading level="h3" size="h5">
               Purpose
             </lux-heading>
-            <text-style variation="default"
+            <lux-text-style variation="default"
               ><%= request_change_set.purpose.blank? ? 'Unknown' : request_change_set.purpose
-              %></text-style
+              %></lux-text-style
             >
             <% if current_staff_profile.department_head? && action == "review" %>
               <lux-heading level="h3" size="h5">
                 Travel Category
               </lux-heading>
-              <input-select label="Travel Category" name="travel_request[travel_category]"
+              <lux-input-select label="Travel Category" name="travel_request[travel_category]"
                   id="travel_request_travel_category" width="expand" hide-label
                   value="<%= request_change_set.travel_category %>"
-                  :options="<%= request_change_set.travel_category_options %>"></input-select>
+                  :options="<%= request_change_set.travel_category_options %>"></lux-input-select>
             <% end %>
-          </card-content>
-        </card>
-      </grid-item>
-      <grid-item columns="lg-4 sm-12" order="order-lg-3">
+          </lux-card-content>
+        </lux-card>
+      </lux-grid-item>
+      <lux-grid-item columns="lg-4 sm-12" order="order-lg-3">
         <%= render 'others_card', event_attendees: request_change_set.event_attendees%>
-      </grid-item>
-      <grid-item columns="lg-4 sm-12" order="order-lg-4">
+      </lux-grid-item>
+      <lux-grid-item columns="lg-4 sm-12" order="order-lg-4">
         <%= render 'team_absent_card', absent_staff: request_change_set.absent_staff(supervisor: current_staff_profile) %>
-      </grid-item>
-      <grid-item columns="lg-4 sm-12" order="order-sm-6 order-lg-5">
+      </lux-grid-item>
+      <lux-grid-item columns="lg-4 sm-12" order="order-sm-6 order-lg-5">
         <%= render 'notes_card', request: request_change_set, render_edit: true %>
-      </grid-item>
-      <grid-item columns="lg-8 sm-12" :offset=true class="travel-estimates" order="order-sm-5 order-lg-6">
+      </lux-grid-item>
+      <lux-grid-item columns="lg-8 sm-12" :offset=true class="travel-estimates" order="order-sm-5 order-lg-6">
         <%= render 'expense_card', estimate_fields_json: request_change_set.estimate_fields_json, estimates_json: request_change_set.estimates_json %>
-      </grid-item>
+      </lux-grid-item>
 
-      <grid-item columns="lg-12 sm-12" order="order-sm-7 order-lg-7">
-        <card size="full-width">
-          <card-content>
+      <lux-grid-item columns="lg-12 sm-12" order="order-sm-7 order-lg-7">
+        <lux-card size="full-width">
+          <lux-card-content>
             <% if action == "review" %>
-              <input-button type="submit" variation="solid" name="approve">Approve</input-button>
-              <input-button type="submit" variation="solid" name="deny">Deny</input-button>
-              <input-button type="submit" variation="solid" name="change_request">Request Changes</input-button>
-              <input-button type="submit" variation="solid" name="change_event">Change Event Name</input-button>
+              <lux-input-button type="submit" variation="solid" name="approve">Approve</lux-input-button>
+              <lux-input-button type="submit" variation="solid" name="deny">Deny</lux-input-button>
+              <lux-input-button type="submit" variation="solid" name="change_request">Request Changes</lux-input-button>
+              <lux-input-button type="submit" variation="solid" name="change_event">Change Event Name</lux-input-button>
             <% else %>
-              <input-button type="submit" variation="solid" name="comment">Comment</input-button>
+              <lux-input-button type="submit" variation="solid" name="comment">Comment</lux-input-button>
             <% end %>
-          </card-content>
-        </card>
-      </grid-item>
+          </lux-card-content>
+        </lux-card>
+      </lux-grid-item>
 
-  </grid-container>
+  </lux-grid-container>
 <% end %>
 </div>

--- a/app/views/travel_requests/_team_absent_card.html.erb
+++ b/app/views/travel_requests/_team_absent_card.html.erb
@@ -1,8 +1,8 @@
 <card size="full-width">
   <card-content>
-    <heading level="h3" size="h5">
+    <lux-heading level="h3" size="h5">
       Team members absent during this time period
-    </heading>
+    </lux-heading>
     <ul class="staff">
       <%= render partial: "shared/absent_staff", collection:
       absent_staff, as: :staff %>

--- a/app/views/travel_requests/_team_absent_card.html.erb
+++ b/app/views/travel_requests/_team_absent_card.html.erb
@@ -1,5 +1,5 @@
-<card size="full-width">
-  <card-content>
+<lux-card size="full-width">
+  <lux-card-content>
     <lux-heading level="h3" size="h5">
       Team members absent during this time period
     </lux-heading>
@@ -7,5 +7,5 @@
       <%= render partial: "shared/absent_staff", collection:
       absent_staff, as: :staff %>
     </ul>
-  </card-content>
-</card>
+  </lux-card-content>
+</lux-card>

--- a/app/views/travel_requests/_title_card.html.erb
+++ b/app/views/travel_requests/_title_card.html.erb
@@ -1,24 +1,24 @@
-<card size="full-width" class="title-card">
-  <card-media>
+<lux-card size="full-width" class="title-card">
+  <lux-card-media>
     <lux-icon-base width="50" height="50" icon-color="rgb(65, 70, 78)">
       <<%= request.travel_category_icon %>></<%= request.travel_category_icon %>>
     </lux-icon-base>
-    <tag
+    <lux-tag
       type="tag"
       size="small"
       :tag-items="[
     {name: '<%= request.latest_status %>', color: '<%= request.status_color %>', icon: '<%= request.status_icon %>'}
     ]"
-    ></tag>
-    <tag
+    ></lux-tag>
+    <lux-tag
       type="tag"
       size="small"
       :tag-items="[
     {name: '<%= request.event_format %>', color: '<%= request.event_format_color %>'}
     ]"
-    ></tag>
-  </card-media>
-  <card-header>
+    ></lux-tag>
+  </lux-card-media>
+  <lux-card-header>
     <lux-heading level="h1" size="h3">
       <span class="event-requestor"
         ><%= request.full_name %></span
@@ -29,13 +29,13 @@
         request.formatted_full_end_date %></span
       >
     </lux-heading>
-  </card-header>
-  <card-content>
+  </lux-card-header>
+  <lux-card-content>
     <div class="status-<%= request.status_color %>">
       <lux-heading level="h2" size="h3"
         ><lux-text-style variation="default">Trip ID</lux-text-style><%=
         request.id %></lux-heading
       >
     </div>
-  </card-content>
-</card>
+  </lux-card-content>
+</lux-card>

--- a/app/views/travel_requests/_title_card.html.erb
+++ b/app/views/travel_requests/_title_card.html.erb
@@ -19,7 +19,7 @@
     ></tag>
   </card-media>
   <card-header>
-    <heading level="h1" size="h3">
+    <lux-heading level="h1" size="h3">
       <span class="event-requestor"
         ><%= request.full_name %></span
       >
@@ -28,13 +28,13 @@
         ><%= request.formatted_full_start_date %> to <%=
         request.formatted_full_end_date %></span
       >
-    </heading>
+    </lux-heading>
   </card-header>
   <card-content>
     <div class="status-<%= request.status_color %>">
-      <heading level="h2" size="h3"
-        ><text-style variation="default">Trip ID</text-style><%=
-        request.id %></heading
+      <lux-heading level="h2" size="h3"
+        ><lux-text-style variation="default">Trip ID</lux-text-style><%=
+        request.id %></lux-heading
       >
     </div>
   </card-content>

--- a/app/views/travel_requests/comment.html.erb
+++ b/app/views/travel_requests/comment.html.erb
@@ -1,8 +1,8 @@
-<wrapper class="review" :max-width=1440>
-  <grid-container>
-    <grid-item columns="lg-12 sm-12">
+<lux-wrapper class="review" :max-width=1440>
+  <lux-grid-container>
+    <lux-grid-item columns="lg-12 sm-12">
       <lux-heading level="h1" size="h2">Comment on Travel Request</lux-heading>
-    </grid-item>
-  </grid-container>
+    </lux-grid-item>
+  </lux-grid-container>
   <%= render 'review_form', request_change_set: @request_change_set, action: 'comment' %>
-</wrapper>
+</lux-wrapper>

--- a/app/views/travel_requests/comment.html.erb
+++ b/app/views/travel_requests/comment.html.erb
@@ -1,7 +1,7 @@
 <wrapper class="review" :max-width=1440>
   <grid-container>
     <grid-item columns="lg-12 sm-12">
-      <heading level="h1" size="h2">Comment on Travel Request</heading>
+      <lux-heading level="h1" size="h2">Comment on Travel Request</lux-heading>
     </grid-item>
   </grid-container>
   <%= render 'review_form', request_change_set: @request_change_set, action: 'comment' %>

--- a/app/views/travel_requests/edit.html.erb
+++ b/app/views/travel_requests/edit.html.erb
@@ -1,8 +1,8 @@
-<wrapper :max-width=1440>
-  <grid-container>
-    <grid-item columns="lg-12 sm-12">
+<lux-wrapper :max-width=1440>
+  <lux-grid-container>
+    <lux-grid-item columns="lg-12 sm-12">
       <lux-heading level="h1" size="h2">Editing Travel Request</lux-heading>
-    </grid-item>
-  </grid-container>
+    </lux-grid-item>
+  </lux-grid-container>
   <%= render 'form', request_change_set: @request_change_set %>
-</wrapper>
+</lux-wrapper>

--- a/app/views/travel_requests/edit.html.erb
+++ b/app/views/travel_requests/edit.html.erb
@@ -1,7 +1,7 @@
 <wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="lg-12 sm-12">
-      <heading level="h1" size="h2">Editing Travel Request</heading>
+      <lux-heading level="h1" size="h2">Editing Travel Request</lux-heading>
     </grid-item>
   </grid-container>
   <%= render 'form', request_change_set: @request_change_set %>

--- a/app/views/travel_requests/new.html.erb
+++ b/app/views/travel_requests/new.html.erb
@@ -1,8 +1,8 @@
-<wrapper :max-width=1440>
-  <grid-container>
-    <grid-item columns="lg-12 sm-12">
+<lux-wrapper :max-width=1440>
+  <lux-grid-container>
+    <lux-grid-item columns="lg-12 sm-12">
       <lux-heading level="h1" size="h2">New Travel Request</lux-heading>
-    </grid-item>
-  </grid-container>
+    </lux-grid-item>
+  </lux-grid-container>
   <%= render 'form', request_change_set: @request_change_set %>
-</wrapper>
+</lux-wrapper>

--- a/app/views/travel_requests/new.html.erb
+++ b/app/views/travel_requests/new.html.erb
@@ -1,7 +1,7 @@
 <wrapper :max-width=1440>
   <grid-container>
     <grid-item columns="lg-12 sm-12">
-      <heading level="h1" size="h2">New Travel Request</heading>
+      <lux-heading level="h1" size="h2">New Travel Request</lux-heading>
     </grid-item>
   </grid-container>
   <%= render 'form', request_change_set: @request_change_set %>

--- a/app/views/travel_requests/review.html.erb
+++ b/app/views/travel_requests/review.html.erb
@@ -1,8 +1,8 @@
-<wrapper class="review" :max-width=1440>
-  <grid-container>
-    <grid-item columns="lg-12 sm-12">
+<lux-wrapper class="review" :max-width=1440>
+  <lux-grid-container>
+    <lux-grid-item columns="lg-12 sm-12">
       <lux-heading level="h1" size="h2">Review Travel Request</lux-heading>
-    </grid-item>
-  </grid-container>
+    </lux-grid-item>
+  </lux-grid-container>
   <%= render 'review_form', request_change_set: @request_change_set, action: 'review' %>
-</wrapper>
+</lux-wrapper>

--- a/app/views/travel_requests/review.html.erb
+++ b/app/views/travel_requests/review.html.erb
@@ -1,7 +1,7 @@
 <wrapper class="review" :max-width=1440>
   <grid-container>
     <grid-item columns="lg-12 sm-12">
-      <heading level="h1" size="h2">Review Travel Request</heading>
+      <lux-heading level="h1" size="h2">Review Travel Request</lux-heading>
     </grid-item>
   </grid-container>
   <%= render 'review_form', request_change_set: @request_change_set, action: 'review' %>

--- a/app/views/travel_requests/show.html.erb
+++ b/app/views/travel_requests/show.html.erb
@@ -1,48 +1,48 @@
 <wrapper :max-width="1440" class="request">
-  <grid-container>
-    <grid-item columns="lg-12 sm-12" order="order-lg-1">
+  <lux-grid-container>
+    <lux-grid-item columns="lg-12 sm-12" order="order-lg-1">
       <%= render 'title_card', request: @request %>
-    </grid-item>
-    <grid-item columns="lg-4 sm-12" order="order-lg-2">
-      <card size="full-width">
-        <card-content>
+    </lux-grid-item>
+    <lux-grid-item columns="lg-4 sm-12" order="order-lg-2">
+      <lux-card size="full-width">
+        <lux-card-content>
           <lux-heading level="h3" size="h5">
             Level of Participation
           </lux-heading>
-          <text-style variation="default"
+          <lux-text-style variation="default"
             ><%= @request.participation.blank? ? 'Unknown' :
-            @request.participation.humanize %></text-style>
+            @request.participation.humanize %></lux-text-style>
           <lux-heading level="h3" size="h5">
             Purpose
           </lux-heading>
-          <text-style variation="default"
+          <lux-text-style variation="default"
             ><%= @request.purpose.blank? ? 'Unknown' : @request.purpose
-            %></text-style>
+            %></lux-text-style>
           <lux-heading level="h3" size="h5">
             Travel Category
           </lux-heading>
-          <text-style variation="default"
+          <lux-text-style variation="default"
             ><%= @request.travel_category.blank? ? 'Unknown' : @request.travel_category
-            %></text-style>
-        </card-content>
-      </card>
-    </grid-item>
-    <grid-item columns="lg-4 sm-12" order="order-lg-3">
+            %></lux-text-style>
+        </lux-card-content>
+      </lux-card>
+    </lux-grid-item>
+    <lux-grid-item columns="lg-4 sm-12" order="order-lg-3">
       <%= render 'others_card', event_attendees: @request.event_attendees%>
-    </grid-item>
-    <grid-item columns="lg-4 sm-12" order="order-lg-4">
+    </lux-grid-item>
+    <lux-grid-item columns="lg-4 sm-12" order="order-lg-4">
       <%= render 'team_absent_card', absent_staff: @request.absent_staff(supervisor: current_staff_profile)%>
-    </grid-item>
-    <grid-item columns="lg-4 sm-12" order="order-lg-5 order-sm-6">
+    </lux-grid-item>
+    <lux-grid-item columns="lg-4 sm-12" order="order-lg-5 order-sm-6">
       <%= render 'notes_card', request: @request, render_edit: false %>
-    </grid-item>
-    <grid-item columns="lg-8 sm-12" :offset=true class="travel-estimates" order="order-lg-6 order-sm-5">
+    </lux-grid-item>
+    <lux-grid-item columns="lg-8 sm-12" :offset=true class="travel-estimates" order="order-lg-6 order-sm-5">
       <%= render 'expense_card', estimate_fields_json: @request.estimate_fields_json, estimates_json: @request.estimates_json %>
-    </grid-item>
-    <grid-item order="order-lg-7 order-sm-7">
+    </lux-grid-item>
+    <lux-grid-item order="order-lg-7 order-sm-7">
       <%= render 'shared/edit_button', request: @request.request, path: edit_travel_request_path(@request.request) %>
       <%= render 'shared/cancel_button', request: @request.request, path: decide_travel_request_path(@request.request) %>
       <%= render 'shared/comment_button', request: @request.request, path: comment_travel_request_path(@request.request) %>
-    </grid-item>
-  </grid-container>
-</wrapper>
+    </lux-grid-item>
+  </lux-grid-container>
+</lux-wrapper>

--- a/app/views/travel_requests/show.html.erb
+++ b/app/views/travel_requests/show.html.erb
@@ -6,21 +6,21 @@
     <grid-item columns="lg-4 sm-12" order="order-lg-2">
       <card size="full-width">
         <card-content>
-          <heading level="h3" size="h5">
+          <lux-heading level="h3" size="h5">
             Level of Participation
-          </heading>
+          </lux-heading>
           <text-style variation="default"
             ><%= @request.participation.blank? ? 'Unknown' :
             @request.participation.humanize %></text-style>
-          <heading level="h3" size="h5">
+          <lux-heading level="h3" size="h5">
             Purpose
-          </heading>
+          </lux-heading>
           <text-style variation="default"
             ><%= @request.purpose.blank? ? 'Unknown' : @request.purpose
             %></text-style>
-          <heading level="h3" size="h5">
+          <lux-heading level="h3" size="h5">
             Travel Category
-          </heading>
+          </lux-heading>
           <text-style variation="default"
             ><%= @request.travel_category.blank? ? 'Unknown' : @request.travel_category
             %></text-style>

--- a/app/views/travel_requests/show.html.erb
+++ b/app/views/travel_requests/show.html.erb
@@ -1,4 +1,4 @@
-<wrapper :max-width="1440" class="request">
+<lux-wrapper :max-width="1440" class="request">
   <lux-grid-container>
     <lux-grid-item columns="lg-12 sm-12" order="order-lg-1">
       <%= render 'title_card', request: @request %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -4,9 +4,9 @@
       <lux-heading level="h1">Absence and Travel Requests</lux-heading>
       <lux-text-style variation="default">An Absence and Travel request workflow application for the Princeton University Library staff. Use this site to request vacation and other absence types from your supervisor, and to submit travel requests with cost estimates. Receive notifications as your request progresses through the required steps. Browse your upcoming and prior requests as needed.</lux-text-style>
       <% if current_user.blank? %>
-        <hyperlink href="/users/auth/cas" variation="button solid" data-method="post" size="large">LOGIN with NetID</hyperlink>
+        <lux-hyperlink href="/users/auth/cas" variation="button solid" data-method="post" size="large">LOGIN with NetID</lux-hyperlink>
       <% else %>
-        <hyperlink href="/sign_out" variation="button solid" size="large">LOGOUT</hyperlink>
+        <lux-hyperlink href="/sign_out" variation="button solid" size="large">LOGOUT</lux-hyperlink>
       <% end %>
     </grid-item>
   </grid-container>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,8 +1,8 @@
 <wrapper>
   <grid-container class="stretch-height">
     <grid-item vertical="center">
-      <heading level="h1">Absence and Travel Requests</heading>
-      <text-style variation="default">An Absence and Travel request workflow application for the Princeton University Library staff. Use this site to request vacation and other absence types from your supervisor, and to submit travel requests with cost estimates. Receive notifications as your request progresses through the required steps. Browse your upcoming and prior requests as needed.</text-style>
+      <lux-heading level="h1">Absence and Travel Requests</lux-heading>
+      <lux-text-style variation="default">An Absence and Travel request workflow application for the Princeton University Library staff. Use this site to request vacation and other absence types from your supervisor, and to submit travel requests with cost estimates. Receive notifications as your request progresses through the required steps. Browse your upcoming and prior requests as needed.</lux-text-style>
       <% if current_user.blank? %>
         <hyperlink href="/users/auth/cas" variation="button solid" data-method="post" size="large">LOGIN with NetID</hyperlink>
       <% else %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,6 +1,6 @@
-<wrapper>
-  <grid-container class="stretch-height">
-    <grid-item vertical="center">
+<lux-wrapper>
+  <lux-grid-container class="stretch-height">
+    <lux-grid-item vertical="center">
       <lux-heading level="h1">Absence and Travel Requests</lux-heading>
       <lux-text-style variation="default">An Absence and Travel request workflow application for the Princeton University Library staff. Use this site to request vacation and other absence types from your supervisor, and to submit travel requests with cost estimates. Receive notifications as your request progresses through the required steps. Browse your upcoming and prior requests as needed.</lux-text-style>
       <% if current_user.blank? %>
@@ -8,6 +8,6 @@
       <% else %>
         <lux-hyperlink href="/sign_out" variation="button solid" size="large">LOGOUT</lux-hyperlink>
       <% end %>
-    </grid-item>
-  </grid-container>
-</wrapper>
+    </lux-grid-item>
+  </lux-grid-container>
+</lux-wrapper>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-alpha.23",
+    "lux-design-system": "^5.0.0-alpha.25",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
     "test": "jest"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-class-properties": "^7.18.6",
+    "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
     "@babel/plugin-transform-runtime": "^7.23.4",
     "@babel/preset-env": "^7.23.3",
     "@happy-dom/jest-environment": "^13.1.4",
     "@vitejs/plugin-vue": "^5.0.1",
-    "@vue/test-utils": "^1.0.0-beta.25",
+    "@vue/test-utils": "^2.0.0-0",
     "@vue/vue3-jest": "29.2.6",
     "babel-core": "^7.0.0-bridge",
     "babel-plugin-dynamic-import-node": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-alpha.21",
+    "lux-design-system": "^5.0.0-alpha.22",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-alpha.19",
+    "lux-design-system": "^5.0.0-alpha.21",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-alpha.14",
+    "lux-design-system": "^5.0.0-alpha.15",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-alpha.15",
+    "lux-design-system": "^5.0.0-alpha.16",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "5.0.0-alpha.12",
+    "lux-design-system": "^5.0.0-alpha.13",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-alpha.13",
+    "lux-design-system": "^5.0.0-alpha.14",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-alpha.32",
+    "lux-design-system": "^5.0.0-alpha.33",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-alpha.31",
+    "lux-design-system": "^5.0.0-alpha.32",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-alpha.27",
+    "lux-design-system": "^5.0.0-alpha.28",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-alpha.25",
+    "lux-design-system": "^5.0.0-alpha.26",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "file:.yalc/lux-design-system",
+    "lux-design-system": "5.0.0-alpha.12",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-alpha.28",
+    "lux-design-system": "^5.0.0-alpha.29",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-alpha.16",
+    "lux-design-system": "^5.0.0-alpha.17",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-alpha.33",
+    "lux-design-system": "^5.0.0-beta.2",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-alpha.26",
+    "lux-design-system": "^5.0.0-alpha.27",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-beta.2",
+    "lux-design-system": "^5.0.0-beta.3",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-alpha.22",
+    "lux-design-system": "^5.0.0-alpha.23",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-alpha.29",
+    "lux-design-system": "^5.0.0-alpha.30",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-alpha.30",
+    "lux-design-system": "^5.0.0-alpha.31",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-alpha.18",
+    "lux-design-system": "^5.0.0-alpha.19",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "approvals",
   "private": true,
   "dependencies": {
-    "postcss-import": "^15.1.0",
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "5.0.0-alpha.10",
+    "lux-design-system": "file:.yalc/lux-design-system",
+    "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },
   "scripts": {
@@ -14,15 +14,16 @@
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.23.4",
     "@babel/preset-env": "^7.23.3",
-    "@happy-dom/jest-environment": "^12.10.3",
+    "@happy-dom/jest-environment": "^13.1.4",
     "@vitejs/plugin-vue": "^5.0.1",
     "@vue/test-utils": "^1.0.0-beta.25",
+    "@vue/vue3-jest": "29.2.6",
     "babel-core": "^7.0.0-bridge",
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "babel-plugin-macros": "^3.1.0",
     "eslint": "^5.11.1",
     "eslint-plugin-import": "^2.14.0",
-    "eslint-plugin-jest": "^27.6.0",
+    "eslint-plugin-jest": "^27.6.3",
     "eslint-plugin-vue": "^9.18.1",
     "jest": "^29.7.0",
     "postcss-flexbugs-fixes": "^5.0.2",
@@ -30,8 +31,7 @@
     "sass": "^1.69.5",
     "vite": "^5.0.12",
     "vite-plugin-ruby": "^5.0.0",
-    "vue-eslint-parser": "^9.3.2",
-    "vue-jest": "^3.0.0"
+    "vue-eslint-parser": "^9.4.0"
   },
   "jest": {
     "roots": [
@@ -51,12 +51,9 @@
       "vue"
     ],
     "transform": {
-      "^.+\\.(js|jsx|ts|tsx)$": "babel-jest",
-      ".*\\.(vue)$": "<rootDir>/node_modules/vue-jest"
-    },
-    "setupFilesAfterEnv": [
-      "./app/javascript/test/setup.js"
-    ]
+      "^.+\\.js$": "babel-jest",
+      "^.+\\.vue$": "@vue/vue3-jest"
+    }
   },
   "resolutions": {
     "jackspeak": "2.1.1"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/ujs": "6.1.7-6",
-    "lux-design-system": "^5.0.0-alpha.17",
+    "lux-design-system": "^5.0.0-alpha.18",
     "postcss-import": "^15.1.0",
     "vue": "^3.4.0"
   },

--- a/spec/features/decide_travel_request_spec.rb
+++ b/spec/features/decide_travel_request_spec.rb
@@ -76,6 +76,8 @@ RSpec.feature "Review Travel Request", type: :feature, js: true do
 
     expect(travel_request.event_title).to match(/Event \d* \d*, Location/)
     fill_in("displayInput", with: "")
+    # The autocomplete dropdown covers the buttons so hit escape to clear
+    find("#displayInput").send_keys(:escape)
     click_on "Change Event Name"
     expect(travel_request.reload.event_title).to match(/Event \d* \d*, Location/)
     expect(page).to have_content("is required to specify requested changes")
@@ -86,6 +88,8 @@ RSpec.feature "Review Travel Request", type: :feature, js: true do
 
     expect(travel_request.event_title).to match(/Event \d* \d*, Location/)
     fill_in("displayInput", with: "Random text")
+    # The autocomplete dropdown covers the buttons so hit escape to clear
+    find("#displayInput").send_keys(:escape)
     click_on "Change Event Name"
     expect(travel_request.reload.event_title).to match(/Event \d* \d*, Location/)
     expect(page).to have_content("Event name does not exist, please select an existing event name.")

--- a/spec/features/decide_travel_request_spec.rb
+++ b/spec/features/decide_travel_request_spec.rb
@@ -76,8 +76,8 @@ RSpec.feature "Review Travel Request", type: :feature, js: true do
 
     expect(travel_request.event_title).to match(/Event \d* \d*, Location/)
     fill_in("displayInput", with: "")
-    # The autocomplete dropdown covers the buttons so hit escape to clear
-    find("#displayInput").send_keys(:escape)
+    # The autocomplete dropdown covers the buttons so hit tab to clear
+    find("#displayInput").send_keys(:tab)
     click_on "Change Event Name"
     expect(travel_request.reload.event_title).to match(/Event \d* \d*, Location/)
     expect(page).to have_content("is required to specify requested changes")
@@ -88,8 +88,8 @@ RSpec.feature "Review Travel Request", type: :feature, js: true do
 
     expect(travel_request.event_title).to match(/Event \d* \d*, Location/)
     fill_in("displayInput", with: "Random text")
-    # The autocomplete dropdown covers the buttons so hit escape to clear
-    find("#displayInput").send_keys(:escape)
+    # The autocomplete dropdown covers the buttons so hit tab to clear
+    find("#displayInput").send_keys(:tab)
     click_on "Change Event Name"
     expect(travel_request.reload.event_title).to match(/Event \d* \d*, Location/)
     expect(page).to have_content("Event name does not exist, please select an existing event name.")

--- a/spec/features/delegate_spec.rb
+++ b/spec/features/delegate_spec.rb
@@ -48,6 +48,7 @@ RSpec.feature "Delegate", type: :feature, js: true do
   end
 
   scenario "I can see my requests and my delegates with pending for absence" do
+    pending "See: https://github.com/pulibrary/approvals/issues/1116"
     FactoryBot.create(:absence_request, creator: staff_profile, start_date: Date.parse("2019-10-12"), end_date: Date.parse("2019-10-13"))
     FactoryBot.create(:absence_request, creator: delegate_staff_profile, start_date: Date.parse("2019-10-12"), end_date: Date.parse("2019-10-13"))
     FactoryBot.create(:absence_request, creator: delegate_staff_profile, start_date: Date.parse("2019-09-12"), end_date: Date.parse("2019-09-13"))

--- a/spec/features/new_absence_request_spec.rb
+++ b/spec/features/new_absence_request_spec.rb
@@ -19,6 +19,7 @@ RSpec.feature "New Absence Request", type: :feature, js: true do
   end
 
   scenario "I can submit a sick day request and cancel it" do
+    pending "See: https://github.com/pulibrary/approvals/issues/1116"
     visit "/"
     click_on "New absence request"
     expect(page).to have_content "New Absence Request"

--- a/spec/features/report_spec.rb
+++ b/spec/features/report_spec.rb
@@ -50,15 +50,17 @@ RSpec.feature "My Requests", type: :feature, js: true do
     expect(page).to have_content "Vacation (15.5 hours) October 13, 2019 October 14, 2019 Approved Sally Smith ITIMS October 20, 2019"
     expect(page).to have_content "Vacation (10.3 hours) October 12, 2019 October 13, 2019 Pending Pat Doe ITIMS"
 
-    select_drop_down(menu: "#status-menu", item: "Approved")
+    click_on "Status"
+    click_on "Approved"
     assert_selector ".my-request tr", count: 5 # header row included in count
-
-    select_drop_down(menu: "#request-type-menu", item: "Travel")
+    click_on "Request type"
+    click_on "Travel"
     assert_selector ".my-request tr", count: 3 # header row included in count
 
     click_link("Status: Approved")
     assert_selector ".my-request tr", count: 4
-
+    # The date range is not currently actually being filled in
+    # You can verify this by turning off "headless" mode and running the test with a byebug after the next line
     fill_in "dateRange", with: "10/10/2019 - 10/25/2019"
     click_on "Filter by Date"
     assert_selector ".my-request tr", count: 2

--- a/spec/services/location_loader_spec.rb
+++ b/spec/services/location_loader_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe LocationLoader, type: :model do
       file.rewind
       file.close
       described_class.load(config_file: file.path)
-      expect(Location.all.map(&:building)).to eq(["Firestone Library", "Other Library"])
+      expect(Location.all.map(&:building)).to contain_exactly("Firestone Library", "Other Library")
       file.unlink
     end
 

--- a/spec/views/absence_requests/edit.html.erb_spec.rb
+++ b/spec/views/absence_requests/edit.html.erb_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe "absence_requests/edit", type: :view do
 
       assert_select "form[action=?][method=?]", absence_request_path(absence_request), "post" do
         assert_select "hours-calculator[start-date=?][end-date=?]", "12/23/2019", "12/27/2019"
-        assert_select "input-select[name=?][value=?]", "absence_request[absence_type]", absence_request.absence_type
+        assert_select "lux-input-select[name=?][value=?]", "absence_request[absence_type]", absence_request.absence_type
         assert_select "lux-input-text[name=?]", "absence_request[notes][content]"
-        assert_select 'input-button[type="submit"]'
+        assert_select 'lux-input-button[type="submit"]'
       end
     end
   end

--- a/spec/views/absence_requests/edit.html.erb_spec.rb
+++ b/spec/views/absence_requests/edit.html.erb_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "absence_requests/edit", type: :view do
       assert_select "form[action=?][method=?]", absence_request_path(absence_request), "post" do
         assert_select "hours-calculator[start-date=?][end-date=?]", "12/23/2019", "12/27/2019"
         assert_select "input-select[name=?][value=?]", "absence_request[absence_type]", absence_request.absence_type
-        assert_select "input-text[name=?]", "absence_request[notes][content]"
+        assert_select "lux-input-text[name=?]", "absence_request[notes][content]"
         assert_select 'input-button[type="submit"]'
       end
     end

--- a/spec/views/absence_requests/new.html.erb_spec.rb
+++ b/spec/views/absence_requests/new.html.erb_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "absence_requests/new", type: :view do
 
       assert_select "form[action=?][method=?]", absence_requests_path, "post" do
         assert_select "hours-calculator[start-date=?][end-date=?]", "12/23/2019", "12/27/2019"
-        assert_select "input-select[name=?][value=?]", "absence_request[absence_type]", absence_request.absence_type
+        assert_select "lux-input-select[name=?][value=?]", "absence_request[absence_type]", absence_request.absence_type
         assert_select "lux-input-text[name=?]", "absence_request[notes][content]"
         assert_select 'lux-input-button[type="submit"]'
       end

--- a/spec/views/absence_requests/new.html.erb_spec.rb
+++ b/spec/views/absence_requests/new.html.erb_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "absence_requests/new", type: :view do
         assert_select "hours-calculator[start-date=?][end-date=?]", "12/23/2019", "12/27/2019"
         assert_select "input-select[name=?][value=?]", "absence_request[absence_type]", absence_request.absence_type
         assert_select "lux-input-text[name=?]", "absence_request[notes][content]"
-        assert_select 'input-button[type="submit"]'
+        assert_select 'lux-input-button[type="submit"]'
       end
     end
   end

--- a/spec/views/absence_requests/new.html.erb_spec.rb
+++ b/spec/views/absence_requests/new.html.erb_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "absence_requests/new", type: :view do
       assert_select "form[action=?][method=?]", absence_requests_path, "post" do
         assert_select "hours-calculator[start-date=?][end-date=?]", "12/23/2019", "12/27/2019"
         assert_select "input-select[name=?][value=?]", "absence_request[absence_type]", absence_request.absence_type
-        assert_select "input-text[name=?]", "absence_request[notes][content]"
+        assert_select "lux-input-text[name=?]", "absence_request[notes][content]"
         assert_select 'input-button[type="submit"]'
       end
     end

--- a/spec/views/absence_requests/show.html.erb_spec.rb
+++ b/spec/views/absence_requests/show.html.erb_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe "absence_requests/show", type: :view do
     expect(rendered).to match(/Vacation \(#{Time.zone.now.strftime('%m/%d/%Y')} to #{Time.zone.tomorrow.strftime('%m/%d/%Y')}\)/)
     expect(rendered).to include("Sally Smith on")
     expect(rendered).to include(absence_request.notes.first.content)
-    expect(rendered).to have_selector("hyperlink[href=\"#{edit_absence_request_path(absence_request.id)}\"]", text: "Edit")
+    expect(rendered).to have_selector("lux-hyperlink[href=\"#{edit_absence_request_path(absence_request.id)}\"]", text: "Edit")
     expect(rendered).to have_selector("form[action=\"#{decide_absence_request_path(absence_request.id)}\"]")
-    expect(rendered).to have_selector("input-button", text: "Cancel")
+    expect(rendered).to have_selector("lux-input-button", text: "Cancel")
   end
 
   context "not the creator" do
@@ -28,7 +28,7 @@ RSpec.describe "absence_requests/show", type: :view do
         allow(view).to receive(:current_staff_profile).and_return(nil)
         render
       end
-      expect(rendered).not_to have_selector("hyperlink[href=\"#{edit_absence_request_path(absence_request.id)}\"]", text: "Edit")
+      expect(rendered).not_to have_selector("lux-hyperlink[href=\"#{edit_absence_request_path(absence_request.id)}\"]", text: "Edit")
       expect(rendered).not_to have_selector("form[action=\"#{decide_absence_request_path(absence_request.id)}\"]")
     end
   end

--- a/spec/views/delegates/index.html.erb_spec.rb
+++ b/spec/views/delegates/index.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "delegates/index", type: :view do
   it "renders new delegate form" do
     render
     assert_select "form[action=?][method=?]", delegates_path, "post" do
-      assert_select "input-autocomplete[name=?]", "delegate[delegate_id]"
+      assert_select "lux-autocomplete-input[name=?]", "delegate[delegate_id]"
     end
   end
 

--- a/spec/views/delegates/index.html.erb_spec.rb
+++ b/spec/views/delegates/index.html.erb_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe "delegates/index", type: :view do
 
   it "renders a list of delegates" do
     render
-    assert_select "card-header", text: /^#{delegate1.delegate}*/, count: 1
-    assert_select "card-header", text: /#{delegate1.delegate.uid}/, count: 1
-    assert_select "card-header", text: /^#{delegate2.delegate}*/, count: 1
-    assert_select "card-header", text: /#{delegate2.delegate.uid}/, count: 1
+    assert_select "lux-card-header", text: /^#{delegate1.delegate}*/, count: 1
+    assert_select "lux-card-header", text: /#{delegate1.delegate.uid}/, count: 1
+    assert_select "lux-card-header", text: /^#{delegate2.delegate}*/, count: 1
+    assert_select "lux-card-header", text: /#{delegate2.delegate.uid}/, count: 1
   end
 end

--- a/spec/views/delegates/to_assume.html.erb_spec.rb
+++ b/spec/views/delegates/to_assume.html.erb_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe "delegates/to_assume", type: :view do
 
   it "renders a list of delegates" do
     render
-    assert_select "card-header", text: /^#{delegate1.delegator}*/, count: 1
-    assert_select "card-header", text: /#{delegate1.delegator.uid}/, count: 1
-    assert_select "card-header", text: /^#{delegate2.delegator}*/, count: 1
-    assert_select "card-header", text: /#{delegate2.delegator.uid}/, count: 1
+    assert_select "lux-card-header", text: /^#{delegate1.delegator}*/, count: 1
+    assert_select "lux-card-header", text: /#{delegate1.delegator.uid}/, count: 1
+    assert_select "lux-card-header", text: /^#{delegate2.delegator}*/, count: 1
+    assert_select "lux-card-header", text: /#{delegate2.delegator.uid}/, count: 1
   end
 end

--- a/spec/views/shared/_flash_messages.html.erb_spec.rb
+++ b/spec/views/shared/_flash_messages.html.erb_spec.rb
@@ -13,7 +13,7 @@ describe "_flash_messages.html.erb" do
     let(:flash_key) { "success" }
     let(:flash_message) { "A Sucessful completion" }
     it "displays an alert" do
-      expect(rendered).to have_selector("alert[status=\"success\"]", text: flash_message)
+      expect(rendered).to have_selector("lux-alert[status=\"success\"]", text: flash_message)
     end
   end
 
@@ -21,7 +21,7 @@ describe "_flash_messages.html.erb" do
     let(:flash_key) { "notice" }
     let(:flash_message) { "A notice completion" }
     it "displays an alert" do
-      expect(rendered).to have_selector("alert[status=\"info\"]", text: flash_message)
+      expect(rendered).to have_selector("lux-alert[status=\"info\"]", text: flash_message)
     end
   end
 
@@ -29,7 +29,7 @@ describe "_flash_messages.html.erb" do
     let(:flash_key) { "error" }
     let(:flash_message) { "An error" }
     it "displays an alert" do
-      expect(rendered).to have_selector("alert[status=\"error\"]", text: flash_message)
+      expect(rendered).to have_selector("lux-alert[status=\"error\"]", text: flash_message)
     end
   end
 
@@ -37,7 +37,7 @@ describe "_flash_messages.html.erb" do
     let(:flash_key) { "alert" }
     let(:flash_message) { "An alert for you" }
     it "displays an alert" do
-      expect(rendered).to have_selector("alert[status=\"warning\"]", text: flash_message)
+      expect(rendered).to have_selector("lux-alert[status=\"warning\"]", text: flash_message)
     end
   end
 end

--- a/spec/views/travel_requests/_review_detail.html.erb_spec.rb
+++ b/spec/views/travel_requests/_review_detail.html.erb_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "travel_requests/_review_detail", type: :view, js: true do
           allow(view).to receive(:travel_request).and_return(travel_request)
           render
         end
-        virtual_badge = Capybara::Node::Simple.new(rendered).all("tag")[1]
+        virtual_badge = Capybara::Node::Simple.new(rendered).all("lux-tag")[1]
         expect(virtual_badge[":tag-items"]).to include("{name: 'Virtual', color: 'green'}")
       end
     end
@@ -22,7 +22,7 @@ RSpec.describe "travel_requests/_review_detail", type: :view, js: true do
           allow(view).to receive(:travel_request).and_return(travel_request)
           render
         end
-        in_person_badge = Capybara::Node::Simple.new(rendered).all("tag")[1]
+        in_person_badge = Capybara::Node::Simple.new(rendered).all("lux-tag")[1]
         expect(in_person_badge[":tag-items"]).to include("{name: 'In-person', color: 'blue'}")
       end
     end
@@ -33,7 +33,7 @@ RSpec.describe "travel_requests/_review_detail", type: :view, js: true do
           allow(view).to receive(:travel_request).and_return(travel_request)
           render
         end
-        expect(Capybara::Node::Simple.new(rendered).all("tag").count).to eq(1)
+        expect(Capybara::Node::Simple.new(rendered).all("lux-tag").count).to eq(1)
       end
     end
   end

--- a/spec/views/travel_requests/edit.html.erb_spec.rb
+++ b/spec/views/travel_requests/edit.html.erb_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe "travel_requests/edit", type: :view do
     assert_select "form[action=?][method=?]", travel_request_path(travel_request), "post" do
       assert_select "travel-request-date-pickers"
       assert_select "input-select[name=?][value=?]", "travel_request[participation]", "presenter"
-      assert_select "input-text[name=?]", "travel_request[notes][][content]"
-      assert_select "input-text[name=?][value=?]", "travel_request[purpose]", travel_request.purpose
-      assert_select "input-text[name=?][value=?]", "travel_request[event_requests_attributes][0][location]", travel_request.event_requests[0].location
+      assert_select "lux-input-text[name=?]", "travel_request[notes][][content]"
+      assert_select "lux-input-text[name=?][value=?]", "travel_request[purpose]", travel_request.purpose
+      assert_select "lux-input-text[name=?][value=?]", "travel_request[event_requests_attributes][0][location]", travel_request.event_requests[0].location
       assert_select "travel-request-button"
     end
   end

--- a/spec/views/travel_requests/edit.html.erb_spec.rb
+++ b/spec/views/travel_requests/edit.html.erb_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "travel_requests/edit", type: :view do
 
     assert_select "form[action=?][method=?]", travel_request_path(travel_request), "post" do
       assert_select "travel-request-date-pickers"
-      assert_select "input-select[name=?][value=?]", "travel_request[participation]", "presenter"
+      assert_select "lux-input-select[name=?][value=?]", "travel_request[participation]", "presenter"
       assert_select "lux-input-text[name=?]", "travel_request[notes][][content]"
       assert_select "lux-input-text[name=?][value=?]", "travel_request[purpose]", travel_request.purpose
       assert_select "lux-input-text[name=?][value=?]", "travel_request[event_requests_attributes][0][location]", travel_request.event_requests[0].location

--- a/spec/views/travel_requests/new.html.erb_spec.rb
+++ b/spec/views/travel_requests/new.html.erb_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe "travel_requests/new", type: :view do
     assert_select "form[action=?][method=?]", travel_requests_path, "post" do
       assert_select "travel-request-date-pickers"
       assert_select "input-select[name=?][value=?]", "travel_request[participation]", "presenter"
-      assert_select "input-text[name=?]", "travel_request[notes][][content]"
-      assert_select "input-text[name=?][value=?]", "travel_request[purpose]", travel_request.purpose
-      assert_select "input-text[name=?][value=?]", "travel_request[event_requests_attributes][0][location]", travel_request.event_requests[0].location
+      assert_select "lux-input-text[name=?]", "travel_request[notes][][content]"
+      assert_select "lux-input-text[name=?][value=?]", "travel_request[purpose]", travel_request.purpose
+      assert_select "lux-input-text[name=?][value=?]", "travel_request[event_requests_attributes][0][location]", travel_request.event_requests[0].location
       assert_select "travel-request-button"
     end
   end

--- a/spec/views/travel_requests/new.html.erb_spec.rb
+++ b/spec/views/travel_requests/new.html.erb_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "travel_requests/new", type: :view do
     render
     assert_select "form[action=?][method=?]", travel_requests_path, "post" do
       assert_select "travel-request-date-pickers"
-      assert_select "input-select[name=?][value=?]", "travel_request[participation]", "presenter"
+      assert_select "lux-input-select[name=?][value=?]", "travel_request[participation]", "presenter"
       assert_select "lux-input-text[name=?]", "travel_request[notes][][content]"
       assert_select "lux-input-text[name=?][value=?]", "travel_request[purpose]", travel_request.purpose
       assert_select "lux-input-text[name=?][value=?]", "travel_request[event_requests_attributes][0][location]", travel_request.event_requests[0].location

--- a/spec/views/travel_requests/show.html.erb_spec.rb
+++ b/spec/views/travel_requests/show.html.erb_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe "travel_requests/show", type: :view do
     expect(rendered).to include("Lodging (per night)")
     expect(rendered).to match(/#{travel_request.estimates.first.amount}/)
     expect(rendered).to match(/#{travel_request.estimates.first.recurrence}/)
-    expect(rendered).to have_selector("hyperlink[href=\"#{edit_travel_request_path(travel_request.request)}\"]", text: "Edit")
+    expect(rendered).to have_selector("lux-hyperlink[href=\"#{edit_travel_request_path(travel_request.request)}\"]", text: "Edit")
     expect(rendered).to have_selector("form[action=\"#{decide_travel_request_path(travel_request.id)}\"]")
-    expect(rendered).to have_selector("input-button", text: "Cancel")
+    expect(rendered).to have_selector("lux-input-button", text: "Cancel")
   end
 
   it "does not render edit if current profile is not the creator" do

--- a/spec/views/welcome/index.html.erb_spec.rb
+++ b/spec/views/welcome/index.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "welcome/index", type: :view do
     end
     render
     expect(rendered).to include("Absence and Travel Requests")
-    expect(rendered).to have_selector("hyperlink[href=\"/users/auth/cas\"]", text: "LOGIN with NetID")
+    expect(rendered).to have_selector("lux-hyperlink[href=\"/users/auth/cas\"]", text: "LOGIN with NetID")
   end
 
   it "renders logout if current profile is set" do
@@ -18,6 +18,6 @@ RSpec.describe "welcome/index", type: :view do
       render
     end
     expect(rendered).to include("Absence and Travel Requests")
-    expect(rendered).to have_selector("hyperlink[href=\"/sign_out\"]", text: "LOGOUT")
+    expect(rendered).to have_selector("lux-hyperlink[href=\"/sign_out\"]", text: "LOGOUT")
   end
 end

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,9 @@ export default defineConfig({
     RubyPlugin(),
     vue()
   ],
+  resolve: {
+    alias: {
+      'vue': 'vue/dist/vue.esm-bundler',
+    },
+  }
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4294,10 +4294,10 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@^5.0.0-alpha.22:
-  version "5.0.0-alpha.22"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.22.tgz#48d2b66b945b03aa2d083f416564c162342daa88"
-  integrity sha512-Sxes6knCDGR/yJutMKw+3ESSUnD4HlbiN5uUgzaYH7vVP+E87ZjBoGVm2C/8l1FCLK0g7sD/rBIm/uaoQ4xfOA==
+lux-design-system@^5.0.0-alpha.23:
+  version "5.0.0-alpha.23"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.23.tgz#0f444ab224c55f9a8dda3d2944533065237a4475"
+  integrity sha512-Xs6XOK/cKbx/q28c7e/OCXS6yt/WQ8z6pFHYxGLgEVVcRvDFSfjvtZ12jquICTZ1tg8cUwWWc2qfYvhVVMmBmg==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4294,10 +4294,10 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@^5.0.0-alpha.15:
-  version "5.0.0-alpha.15"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.15.tgz#5512fd679f4662d69a6b2b9e86eb4a1d239e4e61"
-  integrity sha512-/eLYpZJeT1IVKlxIbY5IC8VOD341ZxUEqvTFAVwPF6IsYTIZsEfmPMXpwQIjQ131igA2OdhsZ8sYeXSJfIctsQ==
+lux-design-system@^5.0.0-alpha.16:
+  version "5.0.0-alpha.16"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.16.tgz#cd849bf042468e8cbd10a4504ab3ce39330d64a5"
+  integrity sha512-5TGkS9YEq/fbjxAlt4jMuvJYrt/25ozLXMBTH1Litbm/9IlJ/81ZuA1wWOZcDvtv2zGXGhN244fDxi9Fr+cj9g==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4294,8 +4294,10 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-"lux-design-system@file:.yalc/lux-design-system":
-  version "5.0.0-alpha.11"
+lux-design-system@5.0.0-alpha.12:
+  version "5.0.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.12.tgz#55a9d799686834342a7e0d413cc12f9ddb426722"
+  integrity sha512-7r8XGUGKtuWaYNca9+UFm+SFj3XbXieRnnORBfQeQXewx6RF64QBc/Lo4otUr7TV4aUpP9Hd9O4EgDW9QV72Dw==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4294,10 +4294,10 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@^5.0.0-alpha.21:
-  version "5.0.0-alpha.21"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.21.tgz#6c607d92674e88e38a69d6b478e9cb7e9d056ddc"
-  integrity sha512-oY8f1yFgZ3H+R2zANCXCexxeYYPB4dIiwu/mkWrXxSlgig+xV2lcPjvEit22iJUjLFF1v4NJuFTwraaJHSMKIw==
+lux-design-system@^5.0.0-alpha.22:
+  version "5.0.0-alpha.22"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.22.tgz#48d2b66b945b03aa2d083f416564c162342daa88"
+  integrity sha512-Sxes6knCDGR/yJutMKw+3ESSUnD4HlbiN5uUgzaYH7vVP+E87ZjBoGVm2C/8l1FCLK0g7sD/rBIm/uaoQ4xfOA==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4378,10 +4378,10 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@^5.0.0-alpha.32:
-  version "5.0.0-alpha.32"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.32.tgz#2dc203c770ea9635e11ee3795ab03301b11333fa"
-  integrity sha512-rZKcx+b2fi3E5kaMR1m+sf1zpuWCUeEdGtH58AWJl0zRLAKpToOUs61s06SJ5Sm7DaIrq2xjeJ3BazmNWuMjNw==
+lux-design-system@^5.0.0-alpha.33:
+  version "5.0.0-alpha.33"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.33.tgz#a87ca328aa30e51f8167ce612f084ab38dfcbe8c"
+  integrity sha512-J4PnZHnK1wUPg9KA5a/+M8UUWnAo5o8O8B7/Rx0dX2K8FTMKaXdT05gEmS+lLBOJwWyGra/EgzfyAFYXAHEWKw==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4294,10 +4294,10 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@^5.0.0-alpha.18:
-  version "5.0.0-alpha.18"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.18.tgz#7e191626a7ce6703ba3d53fa2a0e45146f3830a0"
-  integrity sha512-TGQ8WHE7IuDbEdkjYwq+9QE3UQnp5SpzZ7JoK/fQ2U5jZNRbJiL1HoAnhUnqHPQ7HUs/FY4UGmc77RFriNQ+aQ==
+lux-design-system@^5.0.0-alpha.19:
+  version "5.0.0-alpha.19"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.19.tgz#7527264617d76de796c6c9d8423633b0716c6ac2"
+  integrity sha512-q+9bBTDmveRY5bzhqo3oTGkVABpH5JLdbrwxpUHdx1SPCwe/m2hQ362Sel71O/iC+cyUjAQ3XRlSAKGKZXttcw==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4294,10 +4294,10 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@^5.0.0-alpha.19:
-  version "5.0.0-alpha.19"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.19.tgz#7527264617d76de796c6c9d8423633b0716c6ac2"
-  integrity sha512-q+9bBTDmveRY5bzhqo3oTGkVABpH5JLdbrwxpUHdx1SPCwe/m2hQ362Sel71O/iC+cyUjAQ3XRlSAKGKZXttcw==
+lux-design-system@^5.0.0-alpha.21:
+  version "5.0.0-alpha.21"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.21.tgz#6c607d92674e88e38a69d6b478e9cb7e9d056ddc"
+  integrity sha512-oY8f1yFgZ3H+R2zANCXCexxeYYPB4dIiwu/mkWrXxSlgig+xV2lcPjvEit22iJUjLFF1v4NJuFTwraaJHSMKIw==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4378,10 +4378,10 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@^5.0.0-alpha.28:
-  version "5.0.0-alpha.28"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.28.tgz#632aa43ad7bde35ffa59456300c1d5b7e9c5e675"
-  integrity sha512-zERj0vurfeAkCMAqiYQHKMKbz8HJ93TyH850Y8rUVCjzCiM5dBWEehYVDUau4V1H5P+acwr3nqNpoKWc5XDKDA==
+lux-design-system@^5.0.0-alpha.29:
+  version "5.0.0-alpha.29"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.29.tgz#6a91fc8e0bbed45f58f32adc5e8acf0b31a0fa8c"
+  integrity sha512-TZtMdD5FnqlsfXLZjT+4+eOg4Zowb9LPM7EJFO4AhqqMSWfk/KBXKSYsB8izF4WmtVXpUZWCLEAEIW4Vdpg5Bw==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4294,10 +4294,10 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@^5.0.0-alpha.25:
-  version "5.0.0-alpha.25"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.25.tgz#8155ea6f0ffb68e1c07af1601c89480a16d4335b"
-  integrity sha512-hpit7G4qDaAL+J/IRouSIRF0E3vAkXYNaJska3SzsZugIQ5MRCTzz9HVitht/iiaUgH726yfWKXxp3H05cPIHw==
+lux-design-system@^5.0.0-alpha.26:
+  version "5.0.0-alpha.26"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.26.tgz#0d0ad8494c577b21f00fb44dd03d075d4f32548e"
+  integrity sha512-6ChmZQK+zvl1Mi9ROyI1CsPjHVOfOxm7cuEOdY+ybtj8GBCZrCn1uupvbVS9z4j+ysvtQ8ucSCQZPrl3Jutzsw==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4294,10 +4294,10 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@^5.0.0-alpha.14:
-  version "5.0.0-alpha.14"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.14.tgz#85c3a7243cb63950b72ac90728069429bd535be6"
-  integrity sha512-myVdPxvHut5ntSzHc0O6MDzYPLpDX998xqfoImEnWdDCx6d7HjQr2RQ0zOlRh1hq1dBjLbzhzs7TOF7xgYyDiA==
+lux-design-system@^5.0.0-alpha.15:
+  version "5.0.0-alpha.15"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.15.tgz#5512fd679f4662d69a6b2b9e86eb4a1d239e4e61"
+  integrity sha512-/eLYpZJeT1IVKlxIbY5IC8VOD341ZxUEqvTFAVwPF6IsYTIZsEfmPMXpwQIjQ131igA2OdhsZ8sYeXSJfIctsQ==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4294,10 +4294,10 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@^5.0.0-alpha.16:
-  version "5.0.0-alpha.16"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.16.tgz#cd849bf042468e8cbd10a4504ab3ce39330d64a5"
-  integrity sha512-5TGkS9YEq/fbjxAlt4jMuvJYrt/25ozLXMBTH1Litbm/9IlJ/81ZuA1wWOZcDvtv2zGXGhN244fDxi9Fr+cj9g==
+lux-design-system@^5.0.0-alpha.18:
+  version "5.0.0-alpha.18"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.18.tgz#7e191626a7ce6703ba3d53fa2a0e45146f3830a0"
+  integrity sha512-TGQ8WHE7IuDbEdkjYwq+9QE3UQnp5SpzZ7JoK/fQ2U5jZNRbJiL1HoAnhUnqHPQ7HUs/FY4UGmc77RFriNQ+aQ==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4378,10 +4378,10 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@^5.0.0-alpha.30:
-  version "5.0.0-alpha.30"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.30.tgz#88c32285e4d42df55e9ec63c85c39eb075255111"
-  integrity sha512-6HDVrelj/JvJRrH/HipFM96redaWLjGGgxK17wRjNe+LSnre6PYchj9w1kr1y21QL/sIHNl6UCWnvD6R+h9sqQ==
+lux-design-system@^5.0.0-alpha.31:
+  version "5.0.0-alpha.31"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.31.tgz#3002cc3fd9c5ca6fa4dc74344c4d588b28445c66"
+  integrity sha512-mij/X0KXFA3iFB0E5pxmtOnl4KIe7CJO7d5+UkeycrJEKEhbvvJaMy4m9sqeLs5E8hLKzLkZK11npc+Ckv0Bpw==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1001,6 +1001,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.21.0":
+  version "7.23.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.9.tgz#47791a15e4603bb5f905bc0753801cf21d6345f7"
+  integrity sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.22.15", "@babel/template@^7.3.3":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz#09576efc3830f0430f4548ef971dde1350ef2f38"
@@ -1856,6 +1863,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/lodash@^4.14.165":
+  version "4.14.202"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.202.tgz#f09dbd2fb082d507178b2f2a5c7e74bd72ff98f8"
+  integrity sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==
+
 "@types/node@*":
   version "20.9.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.9.3.tgz#e089e1634436f676ff299596c9531bd2b59fffc6"
@@ -1867,6 +1879,11 @@
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.2.tgz#5950e50960793055845e956c427fc2b0d70c5239"
   integrity sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
+
+"@types/resize-observer-browser@^0.1.7":
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/@types/resize-observer-browser/-/resize-observer-browser-0.1.11.tgz#d3c98d788489d8376b7beac23863b1eebdd3c13c"
+  integrity sha512-cNw5iH8JkMkb3QkCoe7DaZiawbDQEUX8t7iuQaRTyLOyQCR2h+ibBD4GJt7p5yhUHrlOeL7ZtbxNHeipqNsBzQ==
 
 "@types/semver@^7.3.12":
   version "7.5.6"
@@ -2685,6 +2702,18 @@ csstype@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
+
+date-fns-tz@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-2.0.0.tgz#1b14c386cb8bc16fc56fe333d4fc34ae1d1099d5"
+  integrity sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==
+
+date-fns@^2.16.1:
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
+  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
 
 debug@^3.2.7:
   version "3.2.7"
@@ -4241,7 +4270,7 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.21:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4266,10 +4295,11 @@ lru-cache@^6.0.0:
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
 "lux-design-system@file:.yalc/lux-design-system":
-  version "5.0.0-alpha.10"
+  version "5.0.0-alpha.11"
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"
+    v-calendar "^3.1.2"
     vue-draggable-plus "^0.3.5"
     vuex "^4.0.0"
 
@@ -5642,6 +5672,18 @@ util-deprecate@^1.0.2:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+v-calendar@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/v-calendar/-/v-calendar-3.1.2.tgz#fb47320a5469973454f030d850134eebcd2307eb"
+  integrity sha512-QDWrnp4PWCpzUblctgo4T558PrHgHzDtQnTeUNzKxfNf29FkCeFpwGd9bKjAqktaa2aJLcyRl45T5ln1ku34kg==
+  dependencies:
+    "@types/lodash" "^4.14.165"
+    "@types/resize-observer-browser" "^0.1.7"
+    date-fns "^2.16.1"
+    date-fns-tz "^2.0.0"
+    lodash "^4.17.20"
+    vue-screen-utils "^1.0.0-beta.13"
+
 v8-to-istanbul@^9.0.1:
   version "9.1.3"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz#ea456604101cd18005ac2cae3cdd1aa058a6306b"
@@ -5705,6 +5747,11 @@ vue-eslint-parser@^9.4.0:
     esquery "^1.4.0"
     lodash "^4.17.21"
     semver "^7.3.6"
+
+vue-screen-utils@^1.0.0-beta.13:
+  version "1.0.0-beta.13"
+  resolved "https://registry.yarnpkg.com/vue-screen-utils/-/vue-screen-utils-1.0.0-beta.13.tgz#0c739e19f6ffbffab63184aba7b6d710b6a63681"
+  integrity sha512-EJ/8TANKhFj+LefDuOvZykwMr3rrLFPLNb++lNBqPOpVigT2ActRg6icH9RFQVm4nHwlHIHSGm5OY/Clar9yIg==
 
 vue@^3.4.0:
   version "3.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4270,8 +4270,7 @@ lru-cache@^6.0.0:
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"
-    vue "^3.2.13"
-    vuedraggable "^4.1.0"
+    vue-draggable-plus "^0.3.5"
     vuex "^4.0.0"
 
 magic-string@^0.30.5:
@@ -5276,11 +5275,6 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
-sortablejs@1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.14.0.tgz#6d2e17ccbdb25f464734df621d4f35d4ab35b3d8"
-  integrity sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==
-
 "source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.1, source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
@@ -5681,6 +5675,11 @@ vue-component-type-helpers@^1.8.21:
   resolved "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-1.8.27.tgz#e816c82dcffac8bca58833c120ba395c325dfa68"
   integrity sha512-0vOfAtI67UjeO1G6UiX5Kd76CqaQ67wrRZiOe7UAb9Jm6GzlUr/fC7CV90XfwapJRjpCMaZFhv1V0ajWRmE9Dg==
 
+vue-draggable-plus@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/vue-draggable-plus/-/vue-draggable-plus-0.3.5.tgz#e37f2eaf6b50a8aa061952784dbc7cf2be071183"
+  integrity sha512-HqIxV4Wr4U5LRPLRi2oV+EJ4g6ibyRKhuaiH4ZQo+LxK4zrk2XcBk9UyXC88OXp4SAq0XYH4Wco/T3LX5kJ79A==
+
 vue-eslint-parser@^9.3.1:
   version "9.3.2"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-9.3.2.tgz#6f9638e55703f1c77875a19026347548d93fd499"
@@ -5707,7 +5706,7 @@ vue-eslint-parser@^9.4.0:
     lodash "^4.17.21"
     semver "^7.3.6"
 
-vue@^3.2.13, vue@^3.4.0:
+vue@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/vue/-/vue-3.4.0.tgz#0671a2607265c16ab56041174744b6bed8ac2baa"
   integrity sha512-iTE9Ve/7DO/H39+gXHrNkRdnh1jDwPe/fap4brbPKkp1APMkS03OiZ+UY0dwpqtRX0iPWQTkh8Fu3hKgLtaxfA==
@@ -5717,13 +5716,6 @@ vue@^3.2.13, vue@^3.4.0:
     "@vue/runtime-dom" "3.4.0"
     "@vue/server-renderer" "3.4.0"
     "@vue/shared" "3.4.0"
-
-vuedraggable@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/vuedraggable/-/vuedraggable-4.1.0.tgz#edece68adb8a4d9e06accff9dfc9040e66852270"
-  integrity sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==
-  dependencies:
-    sortablejs "1.14.0"
 
 vuex@^4.0.0:
   version "4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4294,10 +4294,10 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@5.0.0-alpha.12:
-  version "5.0.0-alpha.12"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.12.tgz#55a9d799686834342a7e0d413cc12f9ddb426722"
-  integrity sha512-7r8XGUGKtuWaYNca9+UFm+SFj3XbXieRnnORBfQeQXewx6RF64QBc/Lo4otUr7TV4aUpP9Hd9O4EgDW9QV72Dw==
+lux-design-system@^5.0.0-alpha.13:
+  version "5.0.0-alpha.13"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.13.tgz#79a33e048ceb8e8ba45a6d2bc37781a369da70aa"
+  integrity sha512-u2+nFl9G1lECdq5EJ9PRl80KkoVEZdsK5hcn8laWno/gUqSQJLKz6QDN+c1ZJ/2BJswDV7mM8DXhEGVz6EgelA==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4378,10 +4378,10 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@^5.0.0-alpha.31:
-  version "5.0.0-alpha.31"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.31.tgz#3002cc3fd9c5ca6fa4dc74344c4d588b28445c66"
-  integrity sha512-mij/X0KXFA3iFB0E5pxmtOnl4KIe7CJO7d5+UkeycrJEKEhbvvJaMy4m9sqeLs5E8hLKzLkZK11npc+Ckv0Bpw==
+lux-design-system@^5.0.0-alpha.32:
+  version "5.0.0-alpha.32"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.32.tgz#2dc203c770ea9635e11ee3795ab03301b11333fa"
+  integrity sha512-rZKcx+b2fi3E5kaMR1m+sf1zpuWCUeEdGtH58AWJl0zRLAKpToOUs61s06SJ5Sm7DaIrq2xjeJ3BazmNWuMjNw==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4378,15 +4378,16 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@^5.0.0-beta.2:
-  version "5.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-beta.2.tgz#32582b8824f7d6d518da037a3188df27628349e4"
-  integrity sha512-J39KMYcwu0zcLxsyljLgs18KPxUoKZwxqkUNoYsdeDkrfCfjTwUtknDR7fyAQJ2S1GLepNdk9RabEPMv1XXH8Q==
+lux-design-system@^5.0.0-beta.3:
+  version "5.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-beta.3.tgz#19a45ca1809897747e6efa7d099895847cc620d9"
+  integrity sha512-EgPeOQOip/0llSDBHZjzgpG7ZDvln+c5U0t5F1IC2ztvzpyqXG/Wl9Txayp3ZdDg3yXrLggpBHhkdlJChj5TcQ==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"
     v-calendar "^3.1.2"
     vue-draggable-plus "^0.3.5"
+    vue-multiselect "^3.0.0-beta.3"
     vue3-cookies "^1.0.6"
     vuex "^4.0.0"
 
@@ -5850,6 +5851,11 @@ vue-eslint-parser@^9.4.0:
     esquery "^1.4.0"
     lodash "^4.17.21"
     semver "^7.3.6"
+
+vue-multiselect@^3.0.0-beta.3:
+  version "3.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/vue-multiselect/-/vue-multiselect-3.0.0-beta.3.tgz#b1348238a84c435582c3f46f2a9c045b29bb976c"
+  integrity sha512-P7Fx+ovVF7WMERSZ0lw6N3p4H4bnQ3NcaY3ORjzFPv0r/6lpIqvFWmK9Xnwze9mgAvmNV1foI1VWrBmjnfBTLQ==
 
 vue-screen-utils@^1.0.0-beta.13:
   version "1.0.0-beta.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4378,10 +4378,10 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@^5.0.0-alpha.27:
-  version "5.0.0-alpha.27"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.27.tgz#7cde13787636e1bf98533ef03f629b428ab3561e"
-  integrity sha512-xtk+niNUK4VoAR00k9BOcSpj+OH3OUytcOz/up9qZhpU7YErWnkEFm1xh+z9uQLfgL33yU2g3APIHsSM2LQZlg==
+lux-design-system@^5.0.0-alpha.28:
+  version "5.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.28.tgz#632aa43ad7bde35ffa59456300c1d5b7e9c5e675"
+  integrity sha512-zERj0vurfeAkCMAqiYQHKMKbz8HJ93TyH850Y8rUVCjzCiM5dBWEehYVDUau4V1H5P+acwr3nqNpoKWc5XDKDA==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4294,10 +4294,10 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@^5.0.0-alpha.23:
-  version "5.0.0-alpha.23"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.23.tgz#0f444ab224c55f9a8dda3d2944533065237a4475"
-  integrity sha512-Xs6XOK/cKbx/q28c7e/OCXS6yt/WQ8z6pFHYxGLgEVVcRvDFSfjvtZ12jquICTZ1tg8cUwWWc2qfYvhVVMmBmg==
+lux-design-system@^5.0.0-alpha.25:
+  version "5.0.0-alpha.25"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.25.tgz#8155ea6f0ffb68e1c07af1601c89480a16d4335b"
+  integrity sha512-hpit7G4qDaAL+J/IRouSIRF0E3vAkXYNaJska3SzsZugIQ5MRCTzz9HVitht/iiaUgH726yfWKXxp3H05cPIHw==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4378,10 +4378,10 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@^5.0.0-alpha.33:
-  version "5.0.0-alpha.33"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.33.tgz#a87ca328aa30e51f8167ce612f084ab38dfcbe8c"
-  integrity sha512-J4PnZHnK1wUPg9KA5a/+M8UUWnAo5o8O8B7/Rx0dX2K8FTMKaXdT05gEmS+lLBOJwWyGra/EgzfyAFYXAHEWKw==
+lux-design-system@^5.0.0-beta.2:
+  version "5.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-beta.2.tgz#32582b8824f7d6d518da037a3188df27628349e4"
+  integrity sha512-J39KMYcwu0zcLxsyljLgs18KPxUoKZwxqkUNoYsdeDkrfCfjTwUtknDR7fyAQJ2S1GLepNdk9RabEPMv1XXH8Q==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4378,10 +4378,10 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@^5.0.0-alpha.29:
-  version "5.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.29.tgz#6a91fc8e0bbed45f58f32adc5e8acf0b31a0fa8c"
-  integrity sha512-TZtMdD5FnqlsfXLZjT+4+eOg4Zowb9LPM7EJFO4AhqqMSWfk/KBXKSYsB8izF4WmtVXpUZWCLEAEIW4Vdpg5Bw==
+lux-design-system@^5.0.0-alpha.30:
+  version "5.0.0-alpha.30"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.30.tgz#88c32285e4d42df55e9ec63c85c39eb075255111"
+  integrity sha512-6HDVrelj/JvJRrH/HipFM96redaWLjGGgxK17wRjNe+LSnre6PYchj9w1kr1y21QL/sIHNl6UCWnvD6R+h9sqQ==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -298,6 +298,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.6.tgz#ba1c9e512bda72a47e285ae42aff9d2a635a9e3b"
   integrity sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==
 
+"@babel/parser@^7.23.9":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.24.0.tgz#26a3d1ff49031c53a97d03b604375f028746a9ac"
+  integrity sha512-QuP/FxEAzMSjXygs8v4N9dvdXzEHN4W1oF3PxuWAtPo08UdM17u89RDMgjLn/mlc56iM0HlLmVkO/wgR+rDgHg==
+
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.23.3":
   version "7.23.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.23.3.tgz#5cd1c87ba9380d0afb78469292c954fee5d2411a"
@@ -1981,6 +1986,17 @@
     estree-walker "^2.0.2"
     source-map-js "^1.0.2"
 
+"@vue/compiler-core@3.4.21":
+  version "3.4.21"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.4.21.tgz#868b7085378fc24e58c9aed14c8d62110a62be1a"
+  integrity sha512-MjXawxZf2SbZszLPYxaFCjxfibYrzr3eYbKxwpLR9EQN+oaziSu3qKVbwBERj1IFIB8OLUewxB5m/BFzi613og==
+  dependencies:
+    "@babel/parser" "^7.23.9"
+    "@vue/shared" "3.4.21"
+    entities "^4.5.0"
+    estree-walker "^2.0.2"
+    source-map-js "^1.0.2"
+
 "@vue/compiler-dom@3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.4.0.tgz#25d4c1e24a2e37c4136cdc593cd533d371bc573b"
@@ -1988,6 +2004,14 @@
   dependencies:
     "@vue/compiler-core" "3.4.0"
     "@vue/shared" "3.4.0"
+
+"@vue/compiler-dom@3.4.21":
+  version "3.4.21"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.4.21.tgz#0077c355e2008207283a5a87d510330d22546803"
+  integrity sha512-IZC6FKowtT1sl0CR5DpXSiEB5ayw75oT2bma1BEhV7RRR1+cfwLrxc2Z8Zq/RGFzJ8w5r9QtCOvTjQgdn0IKmA==
+  dependencies:
+    "@vue/compiler-core" "3.4.21"
+    "@vue/shared" "3.4.21"
 
 "@vue/compiler-sfc@3.4.0":
   version "3.4.0"
@@ -2004,6 +2028,21 @@
     postcss "^8.4.32"
     source-map-js "^1.0.2"
 
+"@vue/compiler-sfc@3.4.21":
+  version "3.4.21"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.4.21.tgz#4af920dc31ab99e1ff5d152b5fe0ad12181145b2"
+  integrity sha512-me7epoTxYlY+2CUM7hy9PCDdpMPfIwrOvAXud2Upk10g4YLv9UBW7kL798TvMeDhPthkZ0CONNrK2GoeI1ODiQ==
+  dependencies:
+    "@babel/parser" "^7.23.9"
+    "@vue/compiler-core" "3.4.21"
+    "@vue/compiler-dom" "3.4.21"
+    "@vue/compiler-ssr" "3.4.21"
+    "@vue/shared" "3.4.21"
+    estree-walker "^2.0.2"
+    magic-string "^0.30.7"
+    postcss "^8.4.35"
+    source-map-js "^1.0.2"
+
 "@vue/compiler-ssr@3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.4.0.tgz#0e437c6e619ce4ec515d2d77a0a9e67e877cc2cd"
@@ -2011,6 +2050,14 @@
   dependencies:
     "@vue/compiler-dom" "3.4.0"
     "@vue/shared" "3.4.0"
+
+"@vue/compiler-ssr@3.4.21":
+  version "3.4.21"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.4.21.tgz#b84ae64fb9c265df21fc67f7624587673d324fef"
+  integrity sha512-M5+9nI2lPpAsgXOGQobnIueVqc9sisBFexh5yMIMRAPYLa7+5wEJs8iqOZc1WAa9WQbx9GR2twgznU8LTIiZ4Q==
+  dependencies:
+    "@vue/compiler-dom" "3.4.21"
+    "@vue/shared" "3.4.21"
 
 "@vue/devtools-api@^6.0.0-beta.11":
   version "6.5.1"
@@ -2024,6 +2071,13 @@
   dependencies:
     "@vue/shared" "3.4.0"
 
+"@vue/reactivity@3.4.21":
+  version "3.4.21"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.4.21.tgz#affd3415115b8ebf4927c8d2a0d6a24bccfa9f02"
+  integrity sha512-UhenImdc0L0/4ahGCyEzc/pZNwVgcglGy9HVzJ1Bq2Mm9qXOpP8RyNTjookw/gOCUlXSEtuZ2fUg5nrHcoqJcw==
+  dependencies:
+    "@vue/shared" "3.4.21"
+
 "@vue/runtime-core@3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.4.0.tgz#6c49cac6142d941954c68c2888160c8fbcdbfc11"
@@ -2031,6 +2085,14 @@
   dependencies:
     "@vue/reactivity" "3.4.0"
     "@vue/shared" "3.4.0"
+
+"@vue/runtime-core@3.4.21":
+  version "3.4.21"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.4.21.tgz#3749c3f024a64c4c27ecd75aea4ca35634db0062"
+  integrity sha512-pQthsuYzE1XcGZznTKn73G0s14eCJcjaLvp3/DKeYWoFacD9glJoqlNBxt3W2c5S40t6CCcpPf+jG01N3ULyrA==
+  dependencies:
+    "@vue/reactivity" "3.4.21"
+    "@vue/shared" "3.4.21"
 
 "@vue/runtime-dom@3.4.0":
   version "3.4.0"
@@ -2041,6 +2103,15 @@
     "@vue/shared" "3.4.0"
     csstype "^3.1.3"
 
+"@vue/runtime-dom@3.4.21":
+  version "3.4.21"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.4.21.tgz#91f867ef64eff232cac45095ab28ebc93ac74588"
+  integrity sha512-gvf+C9cFpevsQxbkRBS1NpU8CqxKw0ebqMvLwcGQrNpx6gqRDodqKqA+A2VZZpQ9RpK2f9yfg8VbW/EpdFUOJw==
+  dependencies:
+    "@vue/runtime-core" "3.4.21"
+    "@vue/shared" "3.4.21"
+    csstype "^3.1.3"
+
 "@vue/server-renderer@3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.4.0.tgz#7b0c5e71463140c64d05c314f46a07c9dcc62625"
@@ -2049,10 +2120,23 @@
     "@vue/compiler-ssr" "3.4.0"
     "@vue/shared" "3.4.0"
 
+"@vue/server-renderer@3.4.21":
+  version "3.4.21"
+  resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.4.21.tgz#150751579d26661ee3ed26a28604667fa4222a97"
+  integrity sha512-aV1gXyKSN6Rz+6kZ6kr5+Ll14YzmIbeuWe7ryJl5muJ4uwSwY/aStXTixx76TwkZFJLm1aAlA/HSWEJ4EyiMkg==
+  dependencies:
+    "@vue/compiler-ssr" "3.4.21"
+    "@vue/shared" "3.4.21"
+
 "@vue/shared@3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.4.0.tgz#b6e804a4742929f94f0159aafd0a2940621cd8de"
   integrity sha512-Nhh3ed3G1R6HDAWiG6YYFt0Zmq/To6u5vjzwa9TIquGheCXPY6nEdIAO8ZdlwXsWqC2yNLj700FOvShpYt5CEA==
+
+"@vue/shared@3.4.21":
+  version "3.4.21"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.4.21.tgz#de526a9059d0a599f0b429af7037cd0c3ed7d5a1"
+  integrity sha512-PuJe7vDIi6VYSinuEbUIQgMIRZGgM8e4R+G+/dQTk0X1NEdvgvvgv7m+rfmDH1gZzyA1OjjoWskvHlfRNfQf3g==
 
 "@vue/test-utils@^2.0.0-0":
   version "2.4.4"
@@ -4294,21 +4378,29 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@^5.0.0-alpha.26:
-  version "5.0.0-alpha.26"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.26.tgz#0d0ad8494c577b21f00fb44dd03d075d4f32548e"
-  integrity sha512-6ChmZQK+zvl1Mi9ROyI1CsPjHVOfOxm7cuEOdY+ybtj8GBCZrCn1uupvbVS9z4j+ysvtQ8ucSCQZPrl3Jutzsw==
+lux-design-system@^5.0.0-alpha.27:
+  version "5.0.0-alpha.27"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.27.tgz#7cde13787636e1bf98533ef03f629b428ab3561e"
+  integrity sha512-xtk+niNUK4VoAR00k9BOcSpj+OH3OUytcOz/up9qZhpU7YErWnkEFm1xh+z9uQLfgL33yU2g3APIHsSM2LQZlg==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"
     v-calendar "^3.1.2"
     vue-draggable-plus "^0.3.5"
+    vue3-cookies "^1.0.6"
     vuex "^4.0.0"
 
 magic-string@^0.30.5:
   version "0.30.5"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.5.tgz#1994d980bd1c8835dc6e78db7cbd4ae4f24746f9"
   integrity sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.15"
+
+magic-string@^0.30.7:
+  version "0.30.8"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.8.tgz#14e8624246d2bedba70d5462aa99ac9681844613"
+  integrity sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.4.15"
 
@@ -4949,6 +5041,15 @@ postcss@^8.4.32:
   version "8.4.32"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.32.tgz#1dac6ac51ab19adb21b8b34fd2d93a86440ef6c9"
   integrity sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==
+  dependencies:
+    nanoid "^3.3.7"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
+postcss@^8.4.35:
+  version "8.4.35"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.35.tgz#60997775689ce09011edf083a549cea44aabe2f7"
+  integrity sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==
   dependencies:
     nanoid "^3.3.7"
     picocolors "^1.0.0"
@@ -5754,6 +5855,24 @@ vue-screen-utils@^1.0.0-beta.13:
   version "1.0.0-beta.13"
   resolved "https://registry.yarnpkg.com/vue-screen-utils/-/vue-screen-utils-1.0.0-beta.13.tgz#0c739e19f6ffbffab63184aba7b6d710b6a63681"
   integrity sha512-EJ/8TANKhFj+LefDuOvZykwMr3rrLFPLNb++lNBqPOpVigT2ActRg6icH9RFQVm4nHwlHIHSGm5OY/Clar9yIg==
+
+vue3-cookies@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/vue3-cookies/-/vue3-cookies-1.0.6.tgz#c1da41f1f3d6bbea8e75157d49d09dfc2a18ca8a"
+  integrity sha512-a1UvVD0qIgxyOqjlSOwnLnqAnz8ASltugEv8yX+96i/WGZAN9fEDci7xO4HIWZE1uToUnRq9JnFhvfDCSo45OA==
+  dependencies:
+    vue "^3.0.0"
+
+vue@^3.0.0:
+  version "3.4.21"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.4.21.tgz#69ec30e267d358ee3a0ce16612ba89e00aaeb731"
+  integrity sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==
+  dependencies:
+    "@vue/compiler-dom" "3.4.21"
+    "@vue/compiler-sfc" "3.4.21"
+    "@vue/runtime-dom" "3.4.21"
+    "@vue/server-renderer" "3.4.21"
+    "@vue/shared" "3.4.21"
 
 vue@^3.4.0:
   version "3.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -619,7 +619,7 @@
     "@babel/helper-module-transforms" "^7.23.3"
     "@babel/helper-plugin-utils" "^7.22.5"
 
-"@babel/plugin-transform-modules-commonjs@^7.23.3":
+"@babel/plugin-transform-modules-commonjs@^7.2.0", "@babel/plugin-transform-modules-commonjs@^7.23.3":
   version "7.23.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.23.3.tgz#661ae831b9577e52be57dd8356b734f9700b53b4"
   integrity sha512-aVS0F65LKsdNOtcz6FRCpE4OgsP2OFnW46qNxNIX9h3wuzaNcSQsJysuMwqSibC98HPrf2vCgtxKNwS0DAlgcA==
@@ -1365,15 +1365,15 @@
   dependencies:
     eslint-visitor-keys "^3.3.0"
 
-"@happy-dom/jest-environment@^12.10.3":
-  version "12.10.3"
-  resolved "https://registry.yarnpkg.com/@happy-dom/jest-environment/-/jest-environment-12.10.3.tgz#b112580943c84b9beefaa54f2335aed967db5ae7"
-  integrity sha512-6cLNSLhSAE4Pj7QEEHU1fEeJFczSA4TT9WmoMQNZ0Lpb6RTBYPDfil56nD/UqyPy5vq3N2n6BN442KsjhHn7uw==
+"@happy-dom/jest-environment@^13.1.4":
+  version "13.1.4"
+  resolved "https://registry.yarnpkg.com/@happy-dom/jest-environment/-/jest-environment-13.1.4.tgz#c12d6b31d7e38547b4e7e92de9c1cb6b5741a8a4"
+  integrity sha512-u1U43eFXgqkdcwtswS68SQzRAp2ecsTDu9LEd6W2iPAZQOWD+3qHBZN8ic3oJNIYaBGetjk6uchORLnWmh+TGQ==
   dependencies:
     "@jest/environment" "^29.4.0"
     "@jest/fake-timers" "^29.4.0"
     "@jest/types" "^29.4.0"
-    happy-dom "12.10.3"
+    happy-dom "13.1.4"
     jest-mock "^29.4.0"
     jest-util "^29.4.0"
 
@@ -1991,6 +1991,18 @@
     lodash "^4.17.15"
     pretty "^2.0.0"
 
+"@vue/vue3-jest@29.2.6":
+  version "29.2.6"
+  resolved "https://registry.yarnpkg.com/@vue/vue3-jest/-/vue3-jest-29.2.6.tgz#2b32c61d99efa4e72a7d1365972dcf43b595b3f0"
+  integrity sha512-Hy4i2BsV5fUmER5LplYiAeRkLTDCSB3ZbnAeEawXtjto/ILaOnamBAoAvEqARgPpR6NRtiYjSgGKmllMtnFd9g==
+  dependencies:
+    "@babel/plugin-transform-modules-commonjs" "^7.2.0"
+    chalk "^2.1.0"
+    convert-source-map "^1.6.0"
+    css-tree "^2.0.1"
+    source-map "0.5.6"
+    tsconfig "^7.0.0"
+
 abbrev@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz#cf59829b8b4f03f89dda2771cb7f3653828c89bf"
@@ -2033,11 +2045,6 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==
-
 ansi-regex@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
@@ -2052,11 +2059,6 @@ ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
-
-ansi-styles@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
-  integrity sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==
 
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
@@ -2165,11 +2167,6 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
-atob@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
-  integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
-
 autoprefixer@^10.4.16:
   version "10.4.16"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.16.tgz#fad1411024d8670880bdece3970aa72e3572feb8"
@@ -2186,15 +2183,6 @@ available-typed-arrays@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
-
-babel-code-frame@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
-  integrity sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==
-  dependencies:
-    chalk "^1.1.3"
-    esutils "^2.0.2"
-    js-tokens "^3.0.2"
 
 babel-core@^7.0.0-bridge:
   version "7.0.0-bridge.0"
@@ -2213,13 +2201,6 @@ babel-jest@^29.7.0:
     chalk "^4.0.0"
     graceful-fs "^4.2.9"
     slash "^3.0.0"
-
-babel-messages@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
-  integrity sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==
-  dependencies:
-    babel-runtime "^6.22.0"
 
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
@@ -2282,24 +2263,6 @@ babel-plugin-polyfill-regenerator@^0.5.3:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.4.3"
 
-babel-plugin-transform-es2015-modules-commonjs@^6.26.0:
-  version "6.26.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz#58a793863a9e7ca870bdc5a881117ffac27db6f3"
-  integrity sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==
-  dependencies:
-    babel-plugin-transform-strict-mode "^6.24.1"
-    babel-runtime "^6.26.0"
-    babel-template "^6.26.0"
-    babel-types "^6.26.0"
-
-babel-plugin-transform-strict-mode@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
-  integrity sha512-j3KtSpjyLSJxNoCDrhwiJad8kw0gJ9REGj8/CqL0HeRyLnvUNYV9zcqluL6QJSXh3nfsLEmSLvwRfGzrgR96Pw==
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz#b4399239b89b2a011f9ddbe3e4f401fc40cff73b"
@@ -2326,55 +2289,6 @@ babel-preset-jest@^29.6.3:
     babel-plugin-jest-hoist "^29.6.3"
     babel-preset-current-node-syntax "^1.0.0"
 
-babel-runtime@^6.22.0, babel-runtime@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-  integrity sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.11.0"
-
-babel-template@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
-  integrity sha512-PCOcLFW7/eazGUKIoqH97sO9A2UYMahsn/yRQ7uOk37iutwjq7ODtcTNF+iFDSHNfkctqsLRjLP7URnOx0T1fg==
-  dependencies:
-    babel-runtime "^6.26.0"
-    babel-traverse "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    lodash "^4.17.4"
-
-babel-traverse@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
-  integrity sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==
-  dependencies:
-    babel-code-frame "^6.26.0"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    debug "^2.6.8"
-    globals "^9.18.0"
-    invariant "^2.2.2"
-    lodash "^4.17.4"
-
-babel-types@^6.24.1, babel-types@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
-  integrity sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==
-  dependencies:
-    babel-runtime "^6.26.0"
-    esutils "^2.0.2"
-    lodash "^4.17.4"
-    to-fast-properties "^1.0.3"
-
-babylon@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
-  integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
-
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -2384,13 +2298,6 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
-
-bindings@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
-  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
-  dependencies:
-    file-uri-to-path "1.0.0"
 
 boolbase@^1.0.0:
   version "1.0.0"
@@ -2470,17 +2377,6 @@ caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001541:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001563.tgz#aa68a64188903e98f36eb9c56e48fba0c1fe2a32"
   integrity sha512-na2WUmOxnwIZtwnFI2CZ/3er0wdNzU7hN+cPYz/z2ajHThnkWjNBOpEPP4n+4r2WPM847JaMotaJE3bnfzjyKw==
 
-chalk@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
-  integrity sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==
-  dependencies:
-    ansi-styles "^2.2.1"
-    escape-string-regexp "^1.0.2"
-    has-ansi "^2.0.0"
-    strip-ansi "^3.0.0"
-    supports-color "^2.0.0"
-
 chalk@^2.1.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -2554,11 +2450,6 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
-clone@2.x:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
-  integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
-
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -2620,6 +2511,11 @@ config-chain@^1.1.13:
     ini "^1.3.4"
     proto-list "~1.2.1"
 
+convert-source-map@^1.6.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
+  integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
+
 convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
@@ -2631,11 +2527,6 @@ core-js-compat@^3.31.0, core-js-compat@^3.33.1:
   integrity sha512-cNzGqFsh3Ot+529GIXacjTJ7kegdt5fPXxCBVS1G0iaZpuo/tBz399ymceLJveQhFFZ8qThHiP3fzuoQjKN2ow==
   dependencies:
     browserslist "^4.22.1"
-
-core-js@^2.4.0:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
-  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.8.3:
   version "3.35.0"
@@ -2707,20 +2598,18 @@ css-prefers-color-scheme@^9.0.0:
   resolved "https://registry.yarnpkg.com/css-prefers-color-scheme/-/css-prefers-color-scheme-9.0.0.tgz#7e9b74062655ea15490e359cb456a3b9f4c93327"
   integrity sha512-03QGAk/FXIRseDdLb7XAiu6gidQ0Nd8945xuM7VFVPpc6goJsG9uIO8xQjTxwbPdPIIV4o4AJoOJyt8gwDl67g==
 
+css-tree@^2.0.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.3.1.tgz#10264ce1e5442e8572fc82fbe490644ff54b5c20"
+  integrity sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==
+  dependencies:
+    mdn-data "2.0.30"
+    source-map-js "^1.0.1"
+
 css.escape@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==
-
-css@^2.1.0:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
-  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
-  dependencies:
-    inherits "^2.0.3"
-    source-map "^0.6.1"
-    source-map-resolve "^0.5.2"
-    urix "^0.1.0"
 
 cssdb@^7.9.0:
   version "7.9.0"
@@ -2737,21 +2626,6 @@ csstype@^3.1.3:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
-deasync@^0.1.15:
-  version "0.1.29"
-  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.29.tgz#8bbbf9d0b235c561b36edd440b6272f1de6c572c"
-  integrity sha512-EBtfUhVX23CE9GR6m+F8WPeImEE4hR/FW9RkK0PMl9V1t283s0elqsTD8EZjaKX28SY1BW2rYfCgNsAYdpamUw==
-  dependencies:
-    bindings "^1.5.0"
-    node-addon-api "^1.7.1"
-
-debug@^2.6.8:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
-
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
@@ -2765,11 +2639,6 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.4:
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
-
-decode-uri-component@^0.2.0:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
-  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
 dedent@^1.0.0:
   version "1.5.1"
@@ -2985,7 +2854,7 @@ escalade@^3.1.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
@@ -3034,10 +2903,10 @@ eslint-plugin-import@^2.14.0:
     semver "^6.3.1"
     tsconfig-paths "^3.14.2"
 
-eslint-plugin-jest@^27.6.0:
-  version "27.6.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-27.6.0.tgz#e5c0cf735b3c8cad0ef9db5b565b2fc99f5e55ed"
-  integrity sha512-MTlusnnDMChbElsszJvrwD1dN3x6nZl//s4JD23BxB6MgR66TZlL064su24xEIS3VACfAoHV1vgyMgPw8nkdng==
+eslint-plugin-jest@^27.6.3:
+  version "27.6.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-27.6.3.tgz#8acb8b1e45597fe1f4d4cf25163d90119efc12be"
+  integrity sha512-+YsJFVH6R+tOiO3gCJon5oqn4KWc+mDq2leudk8mrp8RFubLOo9CVyi3cib4L7XMpxExmkmBZQTPDYVBzgpgOA==
   dependencies:
     "@typescript-eslint/utils" "^5.10.0"
 
@@ -3241,13 +3110,6 @@ external-editor@^3.0.3:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
-extract-from-css@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/extract-from-css/-/extract-from-css-0.4.4.tgz#1ea7df2e7c7c6eb9922fa08e8adaea486f6f8f92"
-  integrity sha512-41qWGBdtKp9U7sgBxAQ7vonYqSXzgW/SiAYzq4tdWSVhAShvpVCH1nyvPQgjse6EdgbW7Y7ERdT3674/lKr65A==
-  dependencies:
-    css "^2.1.0"
-
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -3302,25 +3164,12 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
-file-uri-to-path@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
-  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
-
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
-
-find-babel-config@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.2.0.tgz#a9b7b317eb5b9860cda9d54740a8c8337a2283a2"
-  integrity sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==
-  dependencies:
-    json5 "^0.5.1"
-    path-exists "^3.0.0"
 
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
@@ -3472,11 +3321,6 @@ globals@^11.1.0, globals@^11.7.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-globals@^9.18.0:
-  version "9.18.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
-  integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
-
 globalthis@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.3.tgz#5852882a52b80dc301b0660273e1ed082f0b6ccf"
@@ -3508,10 +3352,10 @@ graceful-fs@^4.2.9:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
-happy-dom@12.10.3:
-  version "12.10.3"
-  resolved "https://registry.yarnpkg.com/happy-dom/-/happy-dom-12.10.3.tgz#e61985eff163b822c110458be7f81aa4f94ad588"
-  integrity sha512-JzUXOh0wdNGY54oKng5hliuBkq/+aT1V3YpTM+lrN/GoLQTANZsMaIvmHiHe612rauHvPJnDZkZ+5GZR++1Abg==
+happy-dom@13.1.4:
+  version "13.1.4"
+  resolved "https://registry.yarnpkg.com/happy-dom/-/happy-dom-13.1.4.tgz#26592cb6c764526088473ac0030bd1959375c90d"
+  integrity sha512-f8STa4iuJcpXn7YjgqBEemzinyPAdjlHMxlCNbIERdRIjJO9Z9Cj3XW5LuiEhsURFfl0AOWqj0hQitme4gq+Gg==
   dependencies:
     css.escape "^1.5.1"
     entities "^4.5.0"
@@ -3519,13 +3363,6 @@ happy-dom@12.10.3:
     webidl-conversions "^7.0.0"
     whatwg-encoding "^2.0.0"
     whatwg-mimetype "^3.0.0"
-
-has-ansi@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
-  integrity sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==
-  dependencies:
-    ansi-regex "^2.0.0"
 
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
@@ -3641,7 +3478,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3:
+inherits@2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3678,13 +3515,6 @@ internal-slot@^1.0.5:
     get-intrinsic "^1.2.2"
     hasown "^2.0.0"
     side-channel "^1.0.4"
-
-invariant@^2.2.2:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
-  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
-  dependencies:
-    loose-envify "^1.0.0"
 
 is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
   version "3.0.2"
@@ -4278,7 +4108,7 @@ jest@^29.7.0:
     import-local "^3.0.2"
     jest-cli "^29.7.0"
 
-js-beautify@^1.6.12, js-beautify@^1.6.14:
+js-beautify@^1.6.12:
   version "1.14.11"
   resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.14.11.tgz#57b17e009549ac845bdc58eddf8e1862e311314e"
   integrity sha512-rPogWqAfoYh1Ryqqh2agUpVfbxAhbjuN1SmU86dskQUKouRiggUTCO4+2ym9UPXllc2WAp0J+T5qxn7Um3lCdw==
@@ -4288,15 +4118,10 @@ js-beautify@^1.6.12, js-beautify@^1.6.14:
     glob "^10.3.3"
     nopt "^7.2.0"
 
-"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
+js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
-
-js-tokens@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
-  integrity sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==
 
 js-yaml@^3.13.0, js-yaml@^3.13.1:
   version "3.14.1"
@@ -4330,11 +4155,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
-
-json5@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
-  integrity sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==
 
 json5@^1.0.2:
   version "1.0.2"
@@ -4390,17 +4210,10 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.4:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-loose-envify@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
-  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
-  dependencies:
-    js-tokens "^3.0.0 || ^4.0.0"
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -4421,10 +4234,8 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@5.0.0-alpha.10:
+"lux-design-system@file:.yalc/lux-design-system":
   version "5.0.0-alpha.10"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.10.tgz#6bd1458c4b44050346625b8916578714b1dd9478"
-  integrity sha512-A5K6si7BEXtlaq/ba3K0L/YiZmOzPunFrfTOEk3oIH52GGmY4kNqTXJzhMtA3Xo0fuhbI+jnkZJLP+UGvRyyDQ==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"
@@ -4452,6 +4263,11 @@ makeerror@1.0.12:
   integrity sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==
   dependencies:
     tmpl "1.0.5"
+
+mdn-data@2.0.30:
+  version "2.0.30"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.30.tgz#ce4df6f80af6cfbe218ecd5c552ba13c4dfa08cc"
+  integrity sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -4519,11 +4335,6 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.6"
 
-ms@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
-
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -4553,19 +4364,6 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-node-addon-api@^1.7.1:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
-  integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
-
-node-cache@^4.1.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-4.2.1.tgz#efd8474dee4edec4138cdded580f5516500f7334"
-  integrity sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==
-  dependencies:
-    clone "2.x"
-    lodash "^4.17.15"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -4607,11 +4405,6 @@ nth-check@^2.1.1:
   integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
   dependencies:
     boolbase "^1.0.0"
-
-object-assign@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
 object-inspect@^1.13.1, object-inspect@^1.9.0:
   version "1.13.1"
@@ -4741,11 +4534,6 @@ parse-json@^5.0.0, parse-json@^5.2.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
-
-path-exists@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
-  integrity sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -5186,11 +4974,6 @@ regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
-
 regenerator-runtime@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45"
@@ -5262,11 +5045,6 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
-
-resolve-url@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
-  integrity sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==
 
 resolve.exports@^2.0.0:
   version "2.0.2"
@@ -5476,21 +5254,10 @@ sortablejs@1.14.0:
   resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.14.0.tgz#6d2e17ccbdb25f464734df621d4f35d4ab35b3d8"
   integrity sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==
 
-"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2:
+"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.1, source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
-
-source-map-resolve@^0.5.2:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
-  integrity sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==
-  dependencies:
-    atob "^2.1.2"
-    decode-uri-component "^0.2.0"
-    resolve-url "^0.2.1"
-    source-map-url "^0.4.0"
-    urix "^0.1.0"
 
 source-map-support@0.5.13:
   version "0.5.13"
@@ -5500,15 +5267,10 @@ source-map-support@0.5.13:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-url@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.1.tgz#0af66605a745a5a2f91cf1bbf8a7afbc283dec56"
-  integrity sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==
-
-source-map@^0.5.6:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-  integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
+source-map@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+  integrity sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==
 
 source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
@@ -5588,13 +5350,6 @@ string.prototype.trimstart@^1.0.7:
     define-properties "^1.2.0"
     es-abstract "^1.22.1"
 
-strip-ansi@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
-  dependencies:
-    ansi-regex "^2.0.0"
-
 strip-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
@@ -5640,11 +5395,6 @@ strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
-
-supports-color@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
-  integrity sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -5712,11 +5462,6 @@ tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
   integrity sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==
-
-to-fast-properties@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
-  integrity sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
@@ -5871,11 +5616,6 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-urix@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
-  integrity sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==
-
 util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -5909,7 +5649,7 @@ vite@^5.0.12:
   optionalDependencies:
     fsevents "~2.3.3"
 
-vue-eslint-parser@^9.3.1, vue-eslint-parser@^9.3.2:
+vue-eslint-parser@^9.3.1:
   version "9.3.2"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-9.3.2.tgz#6f9638e55703f1c77875a19026347548d93fd499"
   integrity sha512-q7tWyCVaV9f8iQyIA5Mkj/S6AoJ9KBN8IeUSf3XEmBrOtxOZnfTg5s4KClbZBCK3GtnT/+RyCLZyDHuZwTuBjg==
@@ -5922,27 +5662,18 @@ vue-eslint-parser@^9.3.1, vue-eslint-parser@^9.3.2:
     lodash "^4.17.21"
     semver "^7.3.6"
 
-vue-jest@^3.0.0:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/vue-jest/-/vue-jest-3.0.7.tgz#a6d29758a5cb4d750f5d1242212be39be4296a33"
-  integrity sha512-PIOxFM+wsBMry26ZpfBvUQ/DGH2hvp5khDQ1n51g3bN0TwFwTy4J85XVfxTRMukqHji/GnAoGUnlZ5Ao73K62w==
+vue-eslint-parser@^9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-9.4.0.tgz#dfd22302e2992fe45748a76553cef7afa5bdde27"
+  integrity sha512-7KsNBb6gHFA75BtneJsoK/dbZ281whUIwFYdQxA68QrCrGMXYzUMbPDHGcOQ0OocIVKrWSKWXZ4mL7tonCXoUw==
   dependencies:
-    babel-plugin-transform-es2015-modules-commonjs "^6.26.0"
-    chalk "^2.1.0"
-    deasync "^0.1.15"
-    extract-from-css "^0.4.4"
-    find-babel-config "^1.1.0"
-    js-beautify "^1.6.14"
-    node-cache "^4.1.1"
-    object-assign "^4.1.1"
-    source-map "^0.5.6"
-    tsconfig "^7.0.0"
-    vue-template-es2015-compiler "^1.6.0"
-
-vue-template-es2015-compiler@^1.6.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
-  integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
+    debug "^4.3.4"
+    eslint-scope "^7.1.1"
+    eslint-visitor-keys "^3.3.0"
+    espree "^9.3.1"
+    esquery "^1.4.0"
+    lodash "^4.17.21"
+    semver "^7.3.6"
 
 vue@^3.2.13, vue@^3.4.0:
   version "3.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4294,10 +4294,10 @@ lru-cache@^6.0.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.3.tgz#b40014d7d2d16d94130b87297a04a1f24874ae7c"
   integrity sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==
 
-lux-design-system@^5.0.0-alpha.13:
-  version "5.0.0-alpha.13"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.13.tgz#79a33e048ceb8e8ba45a6d2bc37781a369da70aa"
-  integrity sha512-u2+nFl9G1lECdq5EJ9PRl80KkoVEZdsK5hcn8laWno/gUqSQJLKz6QDN+c1ZJ/2BJswDV7mM8DXhEGVz6EgelA==
+lux-design-system@^5.0.0-alpha.14:
+  version "5.0.0-alpha.14"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.0.0-alpha.14.tgz#85c3a7243cb63950b72ac90728069429bd535be6"
+  integrity sha512-myVdPxvHut5ntSzHc0O6MDzYPLpDX998xqfoImEnWdDCx6d7HjQr2RQ0zOlRh1hq1dBjLbzhzs7TOF7xgYyDiA==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,11 @@
     "@babel/highlight" "^7.23.4"
     chalk "^2.4.2"
 
+"@babel/compat-data@^7.20.5", "@babel/compat-data@^7.23.5":
+  version "7.23.5"
+  resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz#ffb878728bb6bdcb6f4510aa51b1be9afb8cfd98"
+  integrity sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==
+
 "@babel/compat-data@^7.22.6", "@babel/compat-data@^7.22.9", "@babel/compat-data@^7.23.3":
   version "7.23.3"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.23.3.tgz#3febd552541e62b5e883a25eb3effd7c7379db11"
@@ -68,6 +73,17 @@
   dependencies:
     "@babel/types" "^7.22.15"
 
+"@babel/helper-compilation-targets@^7.20.7":
+  version "7.23.6"
+  resolved "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz#4d79069b16cbcf1461289eccfbbd81501ae39991"
+  integrity sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==
+  dependencies:
+    "@babel/compat-data" "^7.23.5"
+    "@babel/helper-validator-option" "^7.23.5"
+    browserslist "^4.22.2"
+    lru-cache "^5.1.1"
+    semver "^6.3.1"
+
 "@babel/helper-compilation-targets@^7.22.15", "@babel/helper-compilation-targets@^7.22.6":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz#0698fc44551a26cf29f18d4662d5bf545a6cfc52"
@@ -77,6 +93,21 @@
     "@babel/helper-validator-option" "^7.22.15"
     browserslist "^4.21.9"
     lru-cache "^5.1.1"
+    semver "^6.3.1"
+
+"@babel/helper-create-class-features-plugin@^7.18.6":
+  version "7.23.10"
+  resolved "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.10.tgz#25d55fafbaea31fd0e723820bb6cc3df72edf7ea"
+  integrity sha512-2XpP2XhkXzgxecPNEEK8Vz8Asj9aRxt08oKOqtiZoqV2UGZ5T+EkyP9sXQ9nwMxBIG34a7jmasVqoMop7VdPUw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.22.5"
+    "@babel/helper-environment-visitor" "^7.22.20"
+    "@babel/helper-function-name" "^7.23.0"
+    "@babel/helper-member-expression-to-functions" "^7.23.0"
+    "@babel/helper-optimise-call-expression" "^7.22.5"
+    "@babel/helper-replace-supers" "^7.22.20"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.6"
     semver "^6.3.1"
 
 "@babel/helper-create-class-features-plugin@^7.22.15":
@@ -134,7 +165,7 @@
   dependencies:
     "@babel/types" "^7.22.5"
 
-"@babel/helper-member-expression-to-functions@^7.22.15":
+"@babel/helper-member-expression-to-functions@^7.22.15", "@babel/helper-member-expression-to-functions@^7.23.0":
   version "7.23.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.23.0.tgz#9263e88cc5e41d39ec18c9a3e0eced59a3e7d366"
   integrity sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==
@@ -166,7 +197,7 @@
   dependencies:
     "@babel/types" "^7.22.5"
 
-"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.22.5", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.20.2", "@babel/helper-plugin-utils@^7.22.5", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz#dd7ee3735e8a313b9f7b05a773d892e88e6d7295"
   integrity sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==
@@ -224,6 +255,11 @@
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz#694c30dfa1d09a6534cdfcafbe56789d36aba040"
   integrity sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==
+
+"@babel/helper-validator-option@^7.23.5":
+  version "7.23.5"
+  resolved "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz#907a3fbd4523426285365d1206c423c4c5520307"
+  integrity sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==
 
 "@babel/helper-wrap-function@^7.22.20":
   version "7.22.20"
@@ -285,6 +321,25 @@
   dependencies:
     "@babel/helper-environment-visitor" "^7.22.20"
     "@babel/helper-plugin-utils" "^7.22.5"
+
+"@babel/plugin-proposal-class-properties@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz#b110f59741895f7ec21a6fff696ec46265c446a3"
+  integrity sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.18.6"
+    "@babel/helper-plugin-utils" "^7.18.6"
+
+"@babel/plugin-proposal-object-rest-spread@^7.20.7":
+  version "7.20.7"
+  resolved "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz#aa662940ef425779c75534a5c41e9d936edc390a"
+  integrity sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==
+  dependencies:
+    "@babel/compat-data" "^7.20.5"
+    "@babel/helper-compilation-targets" "^7.20.7"
+    "@babel/helper-plugin-utils" "^7.20.2"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
+    "@babel/plugin-transform-parameters" "^7.20.7"
 
 "@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2":
   version "7.21.0-placeholder-for-preset-env.2"
@@ -713,7 +768,7 @@
     "@babel/helper-skip-transparent-expression-wrappers" "^7.22.5"
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
 
-"@babel/plugin-transform-parameters@^7.23.3":
+"@babel/plugin-transform-parameters@^7.20.7", "@babel/plugin-transform-parameters@^7.23.3":
   version "7.23.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.23.3.tgz#83ef5d1baf4b1072fa6e54b2b0999a7b2527e2af"
   integrity sha512-09lMt6UsUb3/34BbECKVbVwrT9bO6lILWln237z7sLaWnMsTi7Yc9fhX5DLpkJzAGfaReXI22wP41SZmnAA3Vw==
@@ -1982,14 +2037,13 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.4.0.tgz#b6e804a4742929f94f0159aafd0a2940621cd8de"
   integrity sha512-Nhh3ed3G1R6HDAWiG6YYFt0Zmq/To6u5vjzwa9TIquGheCXPY6nEdIAO8ZdlwXsWqC2yNLj700FOvShpYt5CEA==
 
-"@vue/test-utils@^1.0.0-beta.25":
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.3.6.tgz#6656bd8fa44dd088b4ad80ff1ee28abe7e5ddf87"
-  integrity sha512-udMmmF1ts3zwxUJEIAj5ziioR900reDrt6C9H3XpWPsLBx2lpHKoA4BTdd9HNIYbkGltWw+JjWJ+5O6QBwiyEw==
+"@vue/test-utils@^2.0.0-0":
+  version "2.4.4"
+  resolved "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.4.tgz#36ba31f90332fb25a5ab2e553652c21d33057094"
+  integrity sha512-8jkRxz8pNhClAf4Co4ZrpAoFISdvT3nuSkUlY6Ys6rmTpw3DMWG/X3mw3gQ7QJzgCZO9f+zuE2kW57fi09MW7Q==
   dependencies:
-    dom-event-types "^1.0.0"
-    lodash "^4.17.15"
-    pretty "^2.0.0"
+    js-beautify "^1.14.9"
+    vue-component-type-helpers "^1.8.21"
 
 "@vue/vue3-jest@29.2.6":
   version "29.2.6"
@@ -2336,6 +2390,16 @@ browserslist@^4.21.10, browserslist@^4.21.9, browserslist@^4.22.1:
     node-releases "^2.0.13"
     update-browserslist-db "^1.0.13"
 
+browserslist@^4.22.2:
+  version "4.22.3"
+  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.22.3.tgz#299d11b7e947a6b843981392721169e27d60c5a6"
+  integrity sha512-UAp55yfwNv0klWNapjs/ktHoguxuQNGnOzxYmfnXIS+8AsRDZkSDxg7R1AX3GKzn078SBI5dzwzj/Yx0Or0e3A==
+  dependencies:
+    caniuse-lite "^1.0.30001580"
+    electron-to-chromium "^1.4.648"
+    node-releases "^2.0.14"
+    update-browserslist-db "^1.0.13"
+
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
@@ -2376,6 +2440,11 @@ caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001541:
   version "1.0.30001563"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001563.tgz#aa68a64188903e98f36eb9c56e48fba0c1fe2a32"
   integrity sha512-na2WUmOxnwIZtwnFI2CZ/3er0wdNzU7hN+cPYz/z2ajHThnkWjNBOpEPP4n+4r2WPM847JaMotaJE3bnfzjyKw==
+
+caniuse-lite@^1.0.30001580:
+  version "1.0.30001581"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001581.tgz#0dfd4db9e94edbdca67d57348ebc070dece279f4"
+  integrity sha512-whlTkwhqV2tUmP3oYhtNfaWGYHDdS3JYFQBKXxcUR9qqPWsRhFHhoISO2Xnl/g0xyKzht9mI1LZpiNWfMzHixQ==
 
 chalk@^2.1.0, chalk@^2.4.2:
   version "2.4.2"
@@ -2493,15 +2562,6 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
-
-condense-newlines@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/condense-newlines/-/condense-newlines-0.2.1.tgz#3de985553139475d32502c83b02f60684d24c55f"
-  integrity sha512-P7X+QL9Hb9B/c8HI5BFFKmjgBu2XpQuF98WZ9XkO+dBGgk5XgwiQz7o1SmpglNWId3581UcS0SFAWfoIhMHPfg==
-  dependencies:
-    extend-shallow "^2.0.1"
-    is-whitespace "^0.3.0"
-    kind-of "^3.0.2"
 
 config-chain@^1.1.13:
   version "1.1.13"
@@ -2704,11 +2764,6 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-event-types@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/dom-event-types/-/dom-event-types-1.1.0.tgz#120c1f92ddea7758db1ccee0a100a33c39f4701b"
-  integrity sha512-jNCX+uNJ3v38BKvPbpki6j5ItVlnSqVV6vDWGS6rExzCMjsc39frLjm1n91o6YaKK6AZl0wLloItW6C6mr61BQ==
-
 editorconfig@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-1.0.4.tgz#040c9a8e9a6c5288388b87c2db07028aa89f53a3"
@@ -2723,6 +2778,11 @@ electron-to-chromium@^1.4.535:
   version "1.4.590"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.590.tgz#85a428fbabb77265a4804040837ed4f2538e3300"
   integrity sha512-hohItzsQcG7/FBsviCYMtQwUSWvVF7NVqPOnJCErWsAshsP/CR2LAXdmq276RbESNdhxiAq5/vRo1g2pxGXVww==
+
+electron-to-chromium@^1.4.648:
+  version "1.4.651"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.651.tgz#ef1e822233c6fc953df3caf943f78c21b254a080"
+  integrity sha512-jjks7Xx+4I7dslwsbaFocSwqBbGHQmuXBJUK9QBZTIrzPq3pzn6Uf2szFSP728FtLYE3ldiccmlkOM/zhGKCpA==
 
 emittery@^0.13.1:
   version "0.13.1"
@@ -3093,13 +3153,6 @@ expect@^29.7.0:
     jest-matcher-utils "^29.7.0"
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
-
-extend-shallow@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
-  integrity sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==
-  dependencies:
-    is-extendable "^0.1.0"
 
 external-editor@^3.0.3:
   version "3.1.0"
@@ -3552,11 +3605,6 @@ is-boolean-object@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
-is-buffer@^1.1.5:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
-  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
-
 is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
@@ -3575,11 +3623,6 @@ is-date-object@^1.0.1:
   integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
   dependencies:
     has-tostringtag "^1.0.0"
-
-is-extendable@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
-  integrity sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -3672,11 +3715,6 @@ is-weakref@^1.0.2:
   integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
   dependencies:
     call-bind "^1.0.2"
-
-is-whitespace@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/is-whitespace/-/is-whitespace-0.3.0.tgz#1639ecb1be036aec69a54cbb401cfbed7114ab7f"
-  integrity sha512-RydPhl4S6JwAyj0JJjshWJEFG6hNye3pZFBRZaTUfZFwGHxzppNaNOVgQuS/E/SlhrApuMXrpnK1EEIXfdo3Dg==
 
 isarray@^2.0.5:
   version "2.0.5"
@@ -4108,9 +4146,9 @@ jest@^29.7.0:
     import-local "^3.0.2"
     jest-cli "^29.7.0"
 
-js-beautify@^1.6.12:
+js-beautify@^1.14.9:
   version "1.14.11"
-  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.14.11.tgz#57b17e009549ac845bdc58eddf8e1862e311314e"
+  resolved "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.11.tgz#57b17e009549ac845bdc58eddf8e1862e311314e"
   integrity sha512-rPogWqAfoYh1Ryqqh2agUpVfbxAhbjuN1SmU86dskQUKouRiggUTCO4+2ym9UPXllc2WAp0J+T5qxn7Um3lCdw==
   dependencies:
     config-chain "^1.1.13"
@@ -4168,13 +4206,6 @@ json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-kind-of@^3.0.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
-  integrity sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==
-  dependencies:
-    is-buffer "^1.1.5"
-
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -4210,7 +4241,7 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4374,6 +4405,11 @@ node-releases@^2.0.13:
   version "2.0.13"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.13.tgz#d5ed1627c23e3461e819b02e57b75e4899b1c81d"
   integrity sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==
+
+node-releases@^2.0.14:
+  version "2.0.14"
+  resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz#2ffb053bceb8b2be8495ece1ab6ce600c4461b0b"
+  integrity sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==
 
 nopt@^7.2.0:
   version "7.2.0"
@@ -4900,15 +4936,6 @@ pretty-format@^29.7.0:
     "@jest/schemas" "^29.6.3"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
-
-pretty@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pretty/-/pretty-2.0.0.tgz#adbc7960b7bbfe289a557dc5f737619a220d06a5"
-  integrity sha512-G9xUchgTEiNpormdYBl+Pha50gOUovT18IvAe7EYMZ1/f9W/WWMPRn+xI68yXNMUk3QXHDwo/1wV/4NejVNe1w==
-  dependencies:
-    condense-newlines "^0.2.1"
-    extend-shallow "^2.0.1"
-    js-beautify "^1.6.12"
 
 progress@^2.0.0:
   version "2.0.3"
@@ -5648,6 +5675,11 @@ vite@^5.0.12:
     rollup "^4.2.0"
   optionalDependencies:
     fsevents "~2.3.3"
+
+vue-component-type-helpers@^1.8.21:
+  version "1.8.27"
+  resolved "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-1.8.27.tgz#e816c82dcffac8bca58833c120ba395c325dfa68"
+  integrity sha512-0vOfAtI67UjeO1G6UiX5Kd76CqaQ67wrRZiOe7UAb9Jm6GzlUr/fC7CV90XfwapJRjpCMaZFhv1V0ajWRmE9Dg==
 
 vue-eslint-parser@^9.3.1:
   version "9.3.2"


### PR DESCRIPTION
Update vue and vue dependencies to vue3

When starting rails server and running the application, the error that we see and try to fix is:
```
"default" is not exported by "node_modules/vue/dist/vue.runtime.esm-bundler.js", imported by "node_modules/lux-design-system/dist/lux-styleguidist.mjs".
  file: /apps_team/approvals/node_modules/lux-design-system/dist/lux-styleguidist.mjs:1:7
  1: import wr, { openBlock as yt, createElementBlock as Qt, createElementVNode as jt, toDisplayString as ln, createCommen...
            ^
  2: const Ft = (n, e) => {
  3:   const r = n.__vccOpts || n;
  error during build:
  RollupError: "default" is not exported by "node_modules/vue/dist/vue.runtime.esm-bundler.js", imported by "node_modules/lux-design-system/dist/lux-styleguidist.mjs".
      at error (file:///apps_team/approvals/node_modules/rollup/dist/es/shared/parseAst.js:337:30)
      at Module.error (file:///apps_team/approvals/node_modules/rollup/dist/es/shared/node-entry.js:12737:16)
      at Module.traceVariable (file:///apps_team/approvals/node_modules/rollup/dist/es/shared/node-entry.js:13178:29)
```