### PR TITLE
Get eslint passing again

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -9,7 +9,7 @@ globals:
   Atomics: readonly
   SharedArrayBuffer: readonly
 parserOptions:
-  ecmaVersion: 2018
+  ecmaVersion: 2020
   sourceType: module
 parser: vue-eslint-parser
 plugins:

--- a/app/javascript/components/travelEstimateForm.vue
+++ b/app/javascript/components/travelEstimateForm.vue
@@ -239,7 +239,7 @@ export default {
             });
             this.$nextTick(() => {
                 const index = this.expenseData.length - 1;
-                const input = this.$refs?.expense_type?.[index]?.focusSelect();
+                this.$refs?.expense_type?.[index]?.focusSelect();
             });
         },
         deleteExpense(expense) {


### PR DESCRIPTION
[ESlint was unable to parse optional chaining,](https://eslint.org/blog/2020/07/eslint-v7.5.0-released/#optional-chaining-support) since it was using 2018 rules. Also, the line it was complaining about had an unused assignment, let's remove it!