### PR TITLE
Listen for inputvaluechange event, rather than the input event

### DIFF
--- a/app/javascript/components/hoursCalculator.vue
+++ b/app/javascript/components/hoursCalculator.vue
@@ -34,7 +34,7 @@
       :helper="helperCaption"
       :value="localHoursReqested"
       required
-      @input="updateCaption($event)"
+      @inputvaluechange="updateCaption($event)"
     />
   </div>
 </template>

--- a/app/javascript/components/travelEstimateForm.vue
+++ b/app/javascript/components/travelEstimateForm.vue
@@ -110,7 +110,7 @@
             width="expand"
             required
             hide-label
-            @input="updateRecurrence($event, expense)"
+            @inputvaluechange="updateRecurrence($event, expense)"
           />
         </lux-grid-item>
         <lux-grid-item
@@ -127,7 +127,7 @@
             placeholder="$ 0.00"
             required
             hide-label
-            @input="updateAmount($event, expense)"
+            @inputvaluechange="updateAmount($event, expense)"
           />
         </lux-grid-item>
         <lux-grid-item


### PR DESCRIPTION
The input event has changed in lux-styleguidist, since it causes problems with the datepicker.

closes #1050 