### PR TITLE
Get health monitor working

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem "kaminari"
 gem "high_voltage"
 
 # health monitor
-gem "health-monitor-rails", "12.4.0"
+gem "health-monitor-rails", "~> 12.4"
 
 gem "honeybadger"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
-    health-monitor-rails (12.4.0)
+    health-monitor-rails (12.4.1)
       railties (>= 6.1)
     high_voltage (4.0.0)
     honeybadger (5.15.5)
@@ -422,7 +422,7 @@ DEPENDENCIES
   ed25519
   factory_bot_rails
   faker
-  health-monitor-rails (= 12.4.0)
+  health-monitor-rails (~> 12.4)
   high_voltage
   honeybadger
   jbuilder

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -157,16 +157,17 @@ namespace :deploy do
 
   after :finishing, 'deploy:cleanup'
 
-  #   # You can/ should apply this command to a subset of hosts
-# cap --hosts=lib-approvals-staging2.lib.princeton.edu staging application:remove_from_nginx
-desc "Marks the server(s) to be removed from the loadbalancer"
+namespace :application do
+  # You can/ should apply this command to a subset of hosts
+  # cap --hosts=lib-approvals-staging2.lib.princeton.edu staging application:remove_from_nginx
+  desc "Marks the server(s) to be removed from the loadbalancer"
   task :remove_from_nginx do
     count = 0
     on roles(:app) do
       count += 1
     end
     if count > (roles(:app).length / 2)
-      raise "You must run this command on individual servers utilizing the --hosts= switch"
+      raise "You must run this command on no more than half the servers utilizing the --hosts= switch"
     end
     on roles(:app) do
       within release_path do
@@ -174,7 +175,8 @@ desc "Marks the server(s) to be removed from the loadbalancer"
       end
     end
   end
- # You can/ should apply this command to a subset of hosts
+
+  # You can/ should apply this command to a subset of hosts
   # cap --hosts=lib-approvals-staging2.lib.princeton.edu staging application:serve_from_nginx
   desc "Marks the server(s) to be added back to the loadbalancer"
   task :serve_from_nginx do

--- a/config/initializers/health_monitor.rb
+++ b/config/initializers/health_monitor.rb
@@ -11,7 +11,6 @@ Rails.application.config.after_initialize do
 
     config.error_callback = proc do |e|
       Rails.logger.error "Health check failed with: #{e.message}"
-      Honeybadger.notify(e) unless e.is_a(HealthMonitor::Providers::FileAbsenceException)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 Rails.application.routes.draw do
   root "welcome#index"
   get "welcome/index"
+  mount HealthMonitor::Engine, at: "/"
 
   devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
 

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Health Check", type: :request do
+  describe "GET /health" do
+    it "has a health check" do
+      get "/health.json"
+      expect(response).to be_successful
+    end
+
+    it "errors when there's a failure to a critical service" do
+      allow_any_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter).to receive(:execute) do |instance|
+        raise StandardError if database.blank? || instance.pool.db_config.name == database.to_s
+      end
+
+      get "/health.json"
+
+      expect(response).not_to be_successful
+      expect(response).to have_http_status :service_unavailable
+    end
+  end
+end


### PR DESCRIPTION
- Because this app is on Rails 7.2 we can use a newer version of the health check gem
- Add HealthMonitor engine to routes.rb
- Remove Honeybadger alert