### PR TITLE
Update the environment names in the deploy files

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -3,8 +3,8 @@
 set :rvm_ruby_string, :local # use the same ruby as used locally for deployment
 set :rails_env, "production"
 
-server "lib-approvals-prod1", user: "deploy", roles: %i[web app db]
-server "lib-approvals-prod2", user: "deploy", roles: %i[web app db]
+server "lib-approvals-prod1.princeton.edu", user: "deploy", roles: %i[web app db]
+server "lib-approvals-prod2.princeton.edu", user: "deploy", roles: %i[web app db]
 
 namespace :env do
   desc "Set all Approvals environment variable"

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -3,8 +3,8 @@
 set :rvm_ruby_string, :local # use the same ruby as used locally for deployment
 set :rails_env, "staging"
 
-server "lib-approvals-staging1", user: "deploy", roles: %i[web app db]
-server "lib-approvals-staging2", user: "deploy", roles: %i[web app db]
+server "lib-approvals-staging1.princeton.edu", user: "deploy", roles: %i[web app db]
+server "lib-approvals-staging2.princeton.edu", user: "deploy", roles: %i[web app db]
 
 namespace :env do
   desc "Set all Approvals environment variable"


### PR DESCRIPTION
Update the environment names to the FDQN in the cap deploy files for lib-approvals-staging and lib-approvals-production. Related to pulibrary/dacs_handbook#299