### PR TITLE
Fix deploy without sprockets

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -28,6 +28,7 @@ set :log_level, :debug
 # set :pty, true
 set :branch, ENV.fetch("BRANCH", nil) || "main"
 
+set :assets_manifests, ["app/assets/config/manifest.js"]
 # shared_path = "deploy_to/shared"
 # set :assets_prefix, '#{shared_path}/public'
 


### PR DESCRIPTION
This application does not use sprockets as of #971.

However, when running on a fresh VM that does not have leftover sprockets files on it, the deploy fails on the step `deploy:assets:backup_manifest`

@maxkadel fixed this for lockers previously in https://github.com/pulibrary/lockers_and_study_spaces/pull/243, so we get to copy/paste his fix!  We should be sure to do this when we move other applications away from sprockets.